### PR TITLE
Update neper to catch up with Google internal changes through 2019-08-20

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -53,6 +53,13 @@ void check_options_tcp(struct options *opts, struct callbacks *cb)
               "TCP_MIN_RTO must be positive.");
         CHECK(cb, opts->min_rto < (1U << 31) / 1000000,
               "TCP_MIN_RTO * 1,000,000 must be less than 2^31 (nanoseconds).");
+        CHECK(cb, opts->source_port == -1 || opts->local_hosts == NULL,
+              "localhosts may not be specified when specifying source_ports");
+        if (opts->source_port != -1) {
+                CHECK(cb, opts->source_port >= 1 && opts->source_port <= 0xFFFF,
+                        "Source ports need to be in the range of 1..0xFFFF. "
+                        "Best larger than 1024.");
+        }
 }
 
 void check_options_udp(struct options *opts, struct callbacks *cb)

--- a/common.c
+++ b/common.c
@@ -212,6 +212,12 @@ void set_nonblocking(int fd, struct callbacks *cb)
                 PLOG_FATAL(cb, "fcntl");
 }
 
+void set_freebind(int fd, struct callbacks *cb) {
+        int value = true;
+        if (setsockopt(fd, SOL_IP, IP_FREEBIND, &value, sizeof(value)))
+                PLOG_ERROR(cb, "setsockopt(FREEBIND)");
+}
+
 int procfile_int(const char *path, struct callbacks *cb)
 {
         int result = 0;

--- a/common.h
+++ b/common.h
@@ -115,6 +115,7 @@ struct addrinfo **parse_local_hosts(const struct options *opts, int n,
 void set_reuseport(int fd, struct callbacks *cb);
 void set_nonblocking(int fd, struct callbacks *cb);
 void set_reuseaddr(int fd, int on, struct callbacks *cb);
+void set_freebind(int fd, struct callbacks *cb);
 void set_debug(int fd, int onoff, struct callbacks *cb);
 void set_min_rto(int fd, int min_rto_ms, struct callbacks *cb);
 int procfile_int(const char *path, struct callbacks *cb);

--- a/control_plane.c
+++ b/control_plane.c
@@ -203,6 +203,8 @@ static int ctrl_listen(const char *host, const char *port,
                 }
                 set_reuseport(fd_listen, cb);
                 set_reuseaddr(fd_listen, 1, cb);
+                if (opts->freebind)
+                        set_freebind(fd_listen, cb);
                 if (bind(fd_listen, rp->ai_addr, rp->ai_addrlen) == 0)
                         break;
                 PLOG_ERROR(cb, "bind");
@@ -340,7 +342,8 @@ void control_plane_start(struct control_plane *cp, struct addrinfo **ai)
                                              cp->opts, cp->cb);
                 LOG_INFO(cp->cb, "connected to control port");
         } else {
-                cp->ctrl_port = ctrl_listen(NULL, cp->opts->control_port, ai,
+                cp->ctrl_port = ctrl_listen(cp->opts->host,
+                                            cp->opts->control_port, ai,
                                             cp->opts, cp->cb);
                 LOG_INFO(cp->cb, "opened control port");
         }

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -41,6 +41,7 @@ struct flags_parser *add_flags_common(struct flags_parser *fp)
         DEFINE_FLAG(fp, bool,         pin_cpu,       false,   'U', "Pin threads to CPU cores");
         DEFINE_FLAG(fp, bool,         logtostderr,   false,    0,  "Log to stderr");
         DEFINE_FLAG(fp, bool,         nonblocking,   false,    0,  "Make sure syscalls are all nonblocking");
+        DEFINE_FLAG(fp, bool,         freebind,      false,    0,  "Set FREEBIND socket option");
         DEFINE_FLAG(fp, double,       interval,      1.0,     'I', "For how many seconds that a sample is generated");
         DEFINE_FLAG(fp, long long,    max_pacing_rate, 0,     'm', "SO_MAX_PACING_RATE value; use as 32-bit unsigned");
         DEFINE_FLAG_PARSER(fp,        max_pacing_rate, parse_max_pacing_rate);
@@ -61,6 +62,7 @@ struct flags_parser *add_flags_tcp(struct flags_parser *fp)
         /* Define flags common to all TCP main programs */
         DEFINE_FLAG(fp, int,          num_ports,     1,        0,  "Number of server data ports");
         DEFINE_FLAG(fp, bool,         tcp_fastopen,  false,   'X', "Enable TCP fastopen");
+        DEFINE_FLAG(fp, int,          source_port,  -1,        0,  "Sender (source) data port. First data stream will use this port, each next stream will use port one larger than previous one. When not specified, kernel assigns free source ports.");
 #ifndef NO_LIBNUMA
         DEFINE_FLAG(fp, bool,         pin_numa,       false,  'N', "Pin threads to CPU cores");
 #endif

--- a/lib.h
+++ b/lib.h
@@ -86,6 +86,7 @@ struct options {
         bool reuseaddr;
         bool logtostderr;
         bool nonblocking;
+        bool freebind;
         bool tcp_fastopen;
         bool skip_rx_copy;
         double interval;
@@ -94,6 +95,7 @@ struct options {
         const char *host;
         const char *control_port;
         const char *port;
+        int source_port; /* Be aware: undefined in all udp_ variants! */
         const char *all_samples;
         const char secret[32]; /* includes test name */
 


### PR DESCRIPTION
* xweng@: Add support for enabling FREEBIND socket option.
* xweng@: When --host is specified on server side, bind to the given host address.
* dzinn@: Allow specifying the source port used for the data connections
* wsommerfeld@: Add locks around accesses to rusage_start and time_start within run_main_thread()

Signed-off-by: Venkatesh Srinivas <venkateshs@chromium.org>