### PR TITLE
neper: don't collect latency stats in tcp_crr server (#22)

### DIFF
--- a/lib.h
+++ b/lib.h
@@ -116,6 +116,9 @@ struct options {
         int request_size;
         int response_size;
         struct percentiles percentiles;
+
+        /* tcp_crr */
+        bool nostats;
 };
 
 #ifdef __cplusplus

--- a/tcp_crr.c
+++ b/tcp_crr.c
@@ -36,5 +36,8 @@ static const struct neper_fn server_fn = {
 int tcp_crr(struct options *opts, struct callbacks *cb)
 {
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
+        /* tcp_crr server doesn't collect stats, as it uses too much memory. */
+        if (!opts->client)
+                opts->nostats = true;
         return run_main_thread(opts, cb, fn);
 }


### PR DESCRIPTION
For tcp_crr server, a new flow is created for each short-lived
connection.  If we collect stats, flow's neper_stat will be added
to worker thread's neper_stats, and won't be freed until the worker
thread ends.  It will use a lot of memory (~1GB/sec) and cause test
failures.

For other four workloads including tcp_crr client, the number of
flows is specified by command line flag, so the memory useage is
stable.

Fixes: 253d3b405 ("neper: collect stats in *rr servers (#22)")