### PR TITLE
Manually define SO_ZEROCOPY if needed

### DIFF
--- a/common.c
+++ b/common.c
@@ -189,6 +189,9 @@ void set_reuseaddr(int fd, int on, struct callbacks *cb)
 
 void set_zerocopy(int fd, int on, struct callbacks *cb)
 {
+#ifndef SO_ZEROCOPY
+#define SO_ZEROCOPY 60
+#endif
         if (setsockopt(fd, SOL_SOCKET, SO_ZEROCOPY, &on, sizeof(on)))
                 PLOG_ERROR(cb, "setsockopt(SO_ZEROCOPY)");
 }


### PR DESCRIPTION
SO_ZEROCOPY is not defined in EL7 kernel headers, hence the compliation will fail on CentOS7/RHEL7.

Tested: compile on CentOS7