### PR TITLE
neper: optionally enter TIME_WAIT state

### DIFF
--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -54,6 +54,7 @@ struct flags_parser *add_flags_common(struct flags_parser *fp)
         DEFINE_FLAG(fp, const char *, all_samples,   NULL,    'A', "Print all samples? If yes, this is the output file name");
         DEFINE_FLAG_HAS_OPTIONAL_ARGUMENT(fp, all_samples);
         DEFINE_FLAG_PARSER(fp,        all_samples, parse_all_samples);
+        DEFINE_FLAG(fp, bool,         time_wait,     false,    0,  "Do not set SO_LINGER 0. Close gracefully. Active peer will enter TIME_WAIT state");
 
         /* Return the updated fp */
         return (fp);

--- a/lib.h
+++ b/lib.h
@@ -92,6 +92,7 @@ struct options {
         bool tcp_fastopen;
         bool skip_rx_copy;
         bool zerocopy;
+        bool time_wait;
         double interval;
         long long max_pacing_rate;
         const char *local_hosts;

--- a/socket.c
+++ b/socket.c
@@ -57,7 +57,7 @@ static void socket_init_not_established(struct thread *t, int s)
                 set_freebind(s, cb);
         if (opts->zerocopy)
                 set_zerocopy(s, 1, cb);
-        if (opts->client) {
+        if (opts->client && !opts->time_wait) {
                 struct linger l;
                 l.l_onoff = 1;
                 l.l_linger = 0;


### PR DESCRIPTION
Neper clients set socket option SO_LINGER with linger timeout of 0.
This triggers an abortive close, where the socket sends an RST instead
of a FIN when it closes its end of the connection.

This avoids entering TIME_WAIT state, which may exhaust available
sockets with many test connections.

But optionally skip this step, to test the entire normal TCP
lifecycle including TIME_WAIT.

Tested:
  ss -nt state time-wait

  shows no connections with standard tcp_stream

  shows all connections with tcp_stream --time-wait,
  if that option is passed on the client,
  then the TIME_WAIT sockets appear on the server
  (which is apparently the active close side)