### PR TITLE
neper: add support for Linux on RISC-V with musl

### DIFF
--- a/cpuinfo.c
+++ b/cpuinfo.c
@@ -53,7 +53,7 @@ int get_cpuinfo(struct cpuinfo *cpus, int max_cpus, struct callbacks *cb)
                  */
                 if (m == 2) {
                         rtrim(key);
-#if defined(__powerpc__) || defined(__aarch64__)
+#if defined(__powerpc__) || defined(__aarch64__) || defined(__riscv)
                         if (strcmp(ltrim(key), "processor") == 0) {
                                 sscanf(value, "%d", &cpus[n].processor);
                                 n++;

--- a/logging.c
+++ b/logging.c
@@ -152,7 +152,6 @@ static void logging(const char *file, int line, const char *func,
                 fclose(log_file);
                 fflush(stdout);
                 fflush(stderr);
-                fcloseall();
                 exit(1);
         }
 }

--- a/rusage.c
+++ b/rusage.c
@@ -49,7 +49,7 @@ static double get_aggregate_proc_stat_system_time()
                 exit(1);
         }
         /* Return the total system time in seconds */
-        return ((double)(system + irq + softirq) / (double)HZ);
+        return ((double)(system + irq + softirq) / (double)sysconf(_SC_CLK_TCK));
 }
 
 static void secs_to_timeval(double secs, struct timeval *tv)


### PR DESCRIPTION
This includes:

- Switching from `HZ` to `sysconf(_SC_CLK_TCK)` [1]
- Switching to `pthread_setaffinity_np` after the thread has been created [2]
- Removing the GNU specifc [3] fcloseall() as the following exit() will also flush
- Adding support for parsing `/proc/cpuinfo`

[1]: https://man7.org/linux/man-pages/man5/proc.5.html
[2]: https://www.openwall.com/lists/musl/2015/05/08/24
[3]: https://man7.org/linux/man-pages/man3/fcloseall.3.html

Signed-off-by: Michael Hope <mlhx@google.com>