### PR TITLE
Allow neper to run in an unprivileged network namespace

### DIFF
--- a/common.c
+++ b/common.c
@@ -222,18 +222,6 @@ void set_mark(int fd, int mark, struct callbacks *cb) {
                 PLOG_ERROR(cb, "setsockopt(MARK)");
 }
 
-int procfile_int(const char *path, struct callbacks *cb)
-{
-        int result = 0;
-        FILE *f = fopen(path, "r");
-        if (!f)
-                PLOG_FATAL(cb, "fopen '%s'", path);
-        if (fscanf(f, "%d", &result) != 1)
-                PLOG_FATAL(cb, "fscanf");
-        fclose(f);
-        return result;
-}
-
 void fill_random(char *buf, int size)
 {
         int fd, chunk, done = 0;

--- a/common.h
+++ b/common.h
@@ -127,7 +127,6 @@ void set_zerocopy(int fd, int on, struct callbacks *cb);
 void set_freebind(int fd, struct callbacks *cb);
 void set_debug(int fd, int onoff, struct callbacks *cb);
 void set_mark(int fd, int mark, struct callbacks *cb);
-int procfile_int(const char *path, struct callbacks *cb);
 void fill_random(char *buf, int size);
 int do_close(int fd);
 struct addrinfo *copy_addrinfo(const struct addrinfo *);


### PR DESCRIPTION
In unprivileged network namaespaces - that is network namespaces owned by
a non-init user namespace - the sysctls in /proc/sys/net/core are not
accessible.  This caused neper tools to fail on startup since the
procfile_int() call in check_options_common() would hit a fatal error if
it couldn't open /proc/sys/net/core/somaxconn.

Allow neper to run in such a namespace by only making the check if
/proc/sys/net/core/somaxconn is openable.  Since this was the only caller
of procfile_int(), remove it and just open-code the new version within
check_options_common().

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>