### PR TITLE
add flag to enable TCP_TX_DELAY sockopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ available in: [google/psp](https://github.com/google/psp).
 
     max_pacing_rate
     listen_backlog
+    tcp_tx_delay
 
 ### `tcp_rr` and `tcp_crr` options
 

--- a/common.c
+++ b/common.c
@@ -222,6 +222,12 @@ void set_mark(int fd, int mark, struct callbacks *cb) {
                 PLOG_ERROR(cb, "setsockopt(MARK)");
 }
 
+void set_tcp_tx_delay(int fd, int delay, struct callbacks *cb)
+{
+        if (setsockopt(fd, SOL_TCP, TCP_TX_DELAY, &delay, sizeof(delay)))
+                PLOG_ERROR(cb, "setsockopt(TCP_TX_DELAY)");
+}
+
 void fill_random(char *buf, int size)
 {
         int fd, chunk, done = 0;

--- a/common.h
+++ b/common.h
@@ -47,6 +47,10 @@
 #define MSG_ZEROCOPY 0x4000000
 #endif
 
+#ifndef TCP_TX_DELAY
+#define TCP_TX_DELAY 37
+#endif
+
 struct flow;
 struct thread;
 
@@ -127,6 +131,7 @@ void set_zerocopy(int fd, int on, struct callbacks *cb);
 void set_freebind(int fd, struct callbacks *cb);
 void set_debug(int fd, int onoff, struct callbacks *cb);
 void set_mark(int fd, int mark, struct callbacks *cb);
+void set_tcp_tx_delay(int fd, int delay, struct callbacks *cb);
 void fill_random(char *buf, int size);
 int do_close(int fd);
 struct addrinfo *copy_addrinfo(const struct addrinfo *);

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -68,6 +68,7 @@ struct flags_parser *add_flags_tcp(struct flags_parser *fp)
 #ifndef NO_LIBNUMA
         DEFINE_FLAG(fp, bool,         pin_numa,       false,  'N', "Pin threads to CPU cores");
 #endif
+        DEFINE_FLAG(fp, int,          tcp_tx_delay,   0,      't', "Force usec delay in TCP flows");
 
         /* Return the updated fp */
         return (fp);

--- a/lib.h
+++ b/lib.h
@@ -74,6 +74,7 @@ struct options {
         int recv_flags;
         int send_flags;
         int mark;
+        int tcp_tx_delay;
         bool stime_use_proc; /* Enable use of /proc/stat values for stime */
         bool ipv4;
         bool ipv6;

--- a/socket.c
+++ b/socket.c
@@ -57,6 +57,8 @@ static void socket_init_not_established(struct thread *t, int s)
                 set_freebind(s, cb);
         if (opts->zerocopy)
                 set_zerocopy(s, 1, cb);
+        if (opts->tcp_tx_delay)
+                set_tcp_tx_delay(s, opts->tcp_tx_delay, cb);
         if (opts->client && !opts->time_wait) {
                 struct linger l;
                 l.l_onoff = 1;


### PR DESCRIPTION
usage: ./tcp_rr -t 100

Tested:
ran tcp_rr across 2 machines

```
~$ dmesg
[76807.565177] TCP: TCP_TX_DELAY enabled
```