### PR TITLE
Pacing 64bit

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -52,8 +52,8 @@ void check_options_common(struct options *opts, struct callbacks *cb)
               "Number of epoll events must be positive.");
         CHECK(cb, opts->max_pacing_rate >= 0,
               "Max pacing rate must be non-negative.");
-        CHECK(cb, opts->max_pacing_rate <= UINT32_MAX,
-              "Max pacing rate cannot exceed 32 bits.");
+        CHECK(cb, opts->max_pacing_rate <= UINT64_MAX,
+              "Max pacing rate cannot exceed 64 bits.");
 }
 
 void check_options_tcp(struct options *opts, struct callbacks *cb)

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -44,7 +44,7 @@ struct flags_parser *add_flags_common(struct flags_parser *fp)
         DEFINE_FLAG(fp, bool,         nonblocking,   false,    0,  "Make sure syscalls are all nonblocking");
         DEFINE_FLAG(fp, bool,         freebind,      false,    0,  "Set FREEBIND socket option");
         DEFINE_FLAG(fp, double,       interval,      1.0,     'I', "For how many seconds that a sample is generated");
-        DEFINE_FLAG(fp, long long,    max_pacing_rate, 0,     'm', "SO_MAX_PACING_RATE value; use as 32-bit unsigned");
+        DEFINE_FLAG(fp, long long,    max_pacing_rate, 0,     'm', "SO_MAX_PACING_RATE value; use as 64-bit unsigned");
         DEFINE_FLAG_PARSER(fp,        max_pacing_rate, parse_max_pacing_rate);
         DEFINE_FLAG(fp, int,          mark,          0,       'M', "SO_MARK value; use as 32-bit unsigned");
         DEFINE_FLAG(fp, const char *, local_hosts,   NULL,    'L', "Local hostnames or IP addresses");

--- a/socket.c
+++ b/socket.c
@@ -45,10 +45,6 @@ static void socket_init_not_established(struct thread *t, int s)
 
         if (opts->debug)
                 set_debug(s, 1, cb);
-        if (opts->max_pacing_rate) {
-                uint32_t m = opts->max_pacing_rate;
-                setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &m, sizeof(m));
-        }
 	if (opts->mark)
 		set_mark(s, opts->mark, cb);
         if (opts->reuseaddr)
@@ -76,8 +72,14 @@ static void socket_init_not_established(struct thread *t, int s)
 
 static void socket_init_established(struct thread *t, int s)
 {
+        const struct options *opts = t->opts;
         struct callbacks *cb = t->cb;
 
+        if (opts->max_pacing_rate) {
+		/* kernels before 5.10 will silently truncate to 32 bits */
+                uint64_t m = opts->max_pacing_rate;
+                setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &m, sizeof(m));
+        }
         set_nonblocking(s, cb);
 }
 


### PR DESCRIPTION
Linux 5.10 extended SO_MAX_PACING_RATE to 64 bit, allowing more
than 4GB/s per socket.
Adjust variable sizes to pass the full 64 bits to the kernel.
Earlier kernels will silently truncate to 32 bits.

Tested: run experiment with argument bigger than 32 bits.
(It takes a fast link to verify that a single flow can achieve
the requested rate).