### PR TITLE
neper: new option --iostat-ms N prints io statistics periodically

### DIFF
--- a/control_plane.h
+++ b/control_plane.h
@@ -23,13 +23,14 @@ struct control_plane;
 struct options;
 struct countdown_cond;
 struct neper_fn;
+struct thread;
 
 struct control_plane* control_plane_create(struct options *opts,
                                            struct callbacks *cb,
                                            struct countdown_cond *data_pending,
                                            const struct neper_fn *fn);
 void control_plane_start(struct control_plane *cp, struct addrinfo **ai);
-void control_plane_wait_until_done(struct control_plane *cp);
+void control_plane_wait_until_done(struct control_plane *cp, struct thread *t);
 void control_plane_stop(struct control_plane *cp);
 int control_plane_incidents(struct control_plane *cp);
 void control_plane_destroy(struct control_plane *cp);

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -55,6 +55,7 @@ struct flags_parser *add_flags_common(struct flags_parser *fp)
         DEFINE_FLAG_HAS_OPTIONAL_ARGUMENT(fp, all_samples);
         DEFINE_FLAG_PARSER(fp,        all_samples, parse_all_samples);
         DEFINE_FLAG(fp, bool,         time_wait,     false,    0,  "Do not set SO_LINGER 0. Close gracefully. Active peer will enter TIME_WAIT state");
+        DEFINE_FLAG(fp, unsigned long, iostat_ms,    0,        0,  "Print io stats snapshot every this many ms");
 
         /* Return the updated fp */
         return (fp);

--- a/lib.h
+++ b/lib.h
@@ -101,6 +101,7 @@ struct options {
         const char *control_port;
         const char *port;
         int source_port;
+        unsigned long iostat_ms;
         const char *all_samples;
         const char secret[32]; /* includes test name */
         bool async_connect;

--- a/stream.c
+++ b/stream.c
@@ -88,6 +88,8 @@ void stream_handler(struct flow *f, uint32_t events)
                                 n = recv(fd, mbuf, opts->buffer_size,
                                          opts->recv_flags);
                         } while(n == -1 && errno == EINTR);
+                        t->io_stats.rx_ops++;
+                        t->io_stats.rx_bytes += n > 0 ? n : 0;
                         if (n == -1) {
                                 if (errno != EAGAIN)
                                         PLOG_ERROR(t->cb, "read");
@@ -103,6 +105,8 @@ void stream_handler(struct flow *f, uint32_t events)
         if (events & EPOLLOUT)
                 do {
                         n = send(fd, mbuf, opts->buffer_size, opts->send_flags);
+                        t->io_stats.tx_ops++;
+                        t->io_stats.tx_bytes += n > 0 ? n : 0;
                         if (n == -1) {
                                 if (errno != EAGAIN)
                                         PLOG_ERROR(t->cb, "send");

--- a/thread.c
+++ b/thread.c
@@ -570,7 +570,7 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
         pthread_mutex_lock(&time_start_mutex);
         getrusage_enhanced(RUSAGE_SELF, &rusage_start); /* rusage start! */
         pthread_mutex_unlock(&time_start_mutex);
-        control_plane_wait_until_done(cp);
+        control_plane_wait_until_done(cp, ts);
         getrusage_enhanced(RUSAGE_SELF, &rusage_end); /* rusage end! */
 
         stop_worker_threads(cb, opts->num_threads, ts, &ready_barrier,

--- a/thread.h
+++ b/thread.h
@@ -69,6 +69,14 @@ struct rate_limit {
         struct flow **pending_flows;    /* size is flow_count */
 };
 
+/* Store per-thread io stats */
+struct io_stats {
+        uint64_t tx_ops;
+        uint64_t tx_bytes;
+        uint64_t rx_ops;
+        uint64_t rx_bytes;
+};
+
 struct thread {
         int index;
         pthread_t id;
@@ -98,6 +106,7 @@ struct thread {
         struct neper_histo_factory *histo_factory;
         struct neper_stats *stats;
         struct neper_rusage *rusage;
+	struct io_stats io_stats;
         struct countdown_cond *data_pending;
         struct rate_limit rl;
         struct flow **flows;  /* indexed by flow_id(flow) */


### PR DESCRIPTION
This option on the client side periodically prints io statistics (tx and rx operations, bytes and Mbps) so it is possible to monitor throughput variations in real time.

netperf has a similar option.

Tested: run with --iostat-ms 1000