### PR TITLE
neper: use one socket per flow in bidirectional stream mode

### DIFF
--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -140,6 +140,7 @@ struct flags_parser *add_flags_tcp_stream(struct flags_parser *fp)
         DEFINE_FLAG(fp, bool,          skip_rx_copy,    false,    0,  "Skip kernel->user payload copy on receives");
         DEFINE_FLAG(fp, bool,          enable_read,     false,   'r', "Read from flows? enabled by default for the server");
         DEFINE_FLAG(fp, bool,          enable_write,    false,   'w', "Write to flows? Enabled by default for the client");
+        DEFINE_FLAG(fp, bool,          split_bidir ,    false,    0,  "Bidirectional using separate tx/rx sockets");
         DEFINE_FLAG(fp, bool,          enable_tcp_maerts,    false,   'M', "Enables TCP_MAERTS test (server writes and client reads). It overrides enable_read, and enable_write");
         DEFINE_FLAG(fp, bool,          async_connect,   false,   0,  "use non blocking connect");
 

--- a/lib.h
+++ b/lib.h
@@ -107,6 +107,7 @@ struct options {
         bool async_connect;
 
         /* tcp_stream */
+        bool split_bidir;  /* implies enable_read, enable_write, split rx/tx */
         bool enable_read;
         bool enable_write;
         bool enable_tcp_maerts;

--- a/psp_stream_main.c
+++ b/psp_stream_main.c
@@ -50,6 +50,14 @@ int main(int argc, char **argv)
                 else
                         opts.enable_read = true;
         }
+        if (opts.split_bidir) {
+                opts.enable_read = true;
+                opts.enable_write = true;
+                opts.num_flows *= 2;
+        }
+
+        if (opts.enable_read && opts.enable_write)
+                opts.num_flows *= 2;
 
         if (opts.skip_rx_copy)
                 opts.recv_flags = MSG_TRUNC;

--- a/stream.c
+++ b/stream.c
@@ -138,6 +138,18 @@ void stream_handler(struct flow *f, uint32_t events)
                  * e.g. Linux kernel tools/testing/selftests/net/msg_zerocopy.c
                  */
         }
+        if (opts->split_bidir && !opts->client &&
+            events & EPOLLOUT && events & EPOLLOUT) {
+                /* See comments in flow.c on bidirectional traffic:
+                 * we use one socket per direction, incoming data means
+                 * this socket is used for client writes and the server should
+                 * stop writing there. This is meant to be called only once;
+                 * leaving only EPOLLIN prevents this to be called again
+                 * without having to store extra state.
+                 */
+                 flow_mod(f, stream_handler, EPOLLIN, true);
+         }
+
 }
 
 int stream_report(struct thread *ts)

--- a/tcp_stream_main.c
+++ b/tcp_stream_main.c
@@ -50,6 +50,11 @@ int main(int argc, char **argv)
                 else
                         opts.enable_read = true;
         }
+        if (opts.split_bidir) {
+                opts.enable_read = true;
+                opts.enable_write = true;
+                opts.num_flows *= 2;
+        }
 
         if (opts.skip_rx_copy)
                 opts.recv_flags = MSG_TRUNC;


### PR DESCRIPTION
In bidirectional mode, acks are piggybacked behind data and this creates unwanted dependencies between forward and reverse flows.

To solve the problem, IN BIDIRECTIONAL STREAM MODE ONLY we use one tcp socket per direction (the user-specified number of flows is doubled after option parsing), used as follows:
- client and server always read from all sockets
- client sends only on half of the sockets (those witheven f_id). This is done by disabling EPOLLOUT on alternate sockets.
- server starts sending on all sockets, but will stop sending and disable EPOLLOUT on sockets on which data is received. This is done in stream_handler()

The above allows to have half of the sockets in tx, and half in rx, without control plane modifications.

Tested: manual test with -rw and different '-m' values on client and server