### PR TITLE
build CUDA-neper image on workstation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ RUN apt-get update \
 ARG CUDA12_GENCODE='-gencode=arch=compute_90,code=sm_90'
 ARG CUDA12_PTX='-gencode=arch=compute_90,code=compute_90'
 
+# this assumes that kernel hdr files have been copied into ${neper_dir}/usr/,
+# which will then be copied into the container
+COPY usr/ /kernel-includes/
+
 WORKDIR /third_party
 
-RUN git clone -b tcpd https://github.com/google/neper.git
-WORKDIR neper
+COPY ./* ./
+RUN make clean
 RUN make tcp_stream WITH_TCPDEVMEM_CUDA=1
 
 RUN chmod +777 /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,11 @@ RUN apt-get update \
 ARG CUDA12_GENCODE='-gencode=arch=compute_90,code=sm_90'
 ARG CUDA12_PTX='-gencode=arch=compute_90,code=compute_90'
 
-# this assumes that kernel hdr files have been copied into ${neper_dir}/usr/,
-# which will then be copied into the container
-COPY usr/ /kernel-includes/
-
 WORKDIR /third_party
 
-COPY ./* ./
-RUN make clean
+# this assumes that kernel hdr files have been copied into ${neper_dir}/usr/,
+# which will then be copied into the container
+COPY . /third_party
 RUN make tcp_stream WITH_TCPDEVMEM_CUDA=1
 
 RUN chmod +777 /tmp

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: binaries
 CFLAGS := -std=c99 -Wall -O3 -g -D_GNU_SOURCE -DNO_LIBNUMA
 
 ifdef WITH_TCPDEVMEM_CUDA
-	CFLAGS += -DWITH_TCPDEVMEM_CUDA
+	CFLAGS += -DWITH_TCPDEVMEM_CUDA -I/kernel-includes/include
 endif
 ifdef WITH_TCPDEVMEM_UDMA
 	CFLAGS += -DWITH_TCPDEVMEM_UDMA -DNDEBUG=1 -static -I ~/cos-kernel/usr/include
@@ -86,7 +86,7 @@ psp_rr-objs := psp_rr_main.o psp_rr.o rr.o psp_lib.o $(lib)
 ext-libs := -lm -lrt -lpthread
 
 tcpdevmem_cuda.o: tcpdevmem_cuda.cu
-	nvcc -arch=sm_90 -O3 -g -D_GNU_SOURCE -DNO_LIBNUMA -DWITH_TCPDEVMEM_CUDA -c -o $@ $^
+	nvcc -arch=sm_90 -O3 -g -I/kernel-includes/include -D_GNU_SOURCE -DNO_LIBNUMA -DWITH_TCPDEVMEM_CUDA -c -o $@ $^
 
 tcp_rr: $(tcp_rr-objs)
 	$(CC) $(LDFLAGS) -o $@ $^ $(ext-libs)

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ all: binaries
 CFLAGS := -std=c99 -Wall -O3 -g -D_GNU_SOURCE -DNO_LIBNUMA
 
 ifdef WITH_TCPDEVMEM_CUDA
-	CFLAGS += -DWITH_TCPDEVMEM_CUDA -I/kernel-includes/include
+	CFLAGS += -DWITH_TCPDEVMEM_CUDA -I usr/include
 endif
 ifdef WITH_TCPDEVMEM_UDMA
-	CFLAGS += -DWITH_TCPDEVMEM_UDMA -DNDEBUG=1 -static -I ~/cos-kernel/usr/include
+	CFLAGS += -DWITH_TCPDEVMEM_UDMA -DNDEBUG=1 -static -I usr/include
 	LDFLAGS += -static
 endif
 
@@ -86,7 +86,7 @@ psp_rr-objs := psp_rr_main.o psp_rr.o rr.o psp_lib.o $(lib)
 ext-libs := -lm -lrt -lpthread
 
 tcpdevmem_cuda.o: tcpdevmem_cuda.cu
-	nvcc -arch=sm_90 -O3 -g -I/kernel-includes/include -D_GNU_SOURCE -DNO_LIBNUMA -DWITH_TCPDEVMEM_CUDA -c -o $@ $^
+	nvcc -arch=sm_90 -O3 -g -I usr/include -D_GNU_SOURCE -DNO_LIBNUMA -DWITH_TCPDEVMEM_CUDA -c -o $@ $^
 
 tcp_rr: $(tcp_rr-objs)
 	$(CC) $(LDFLAGS) -o $@ $^ $(ext-libs)

--- a/README_tcpdevmem.md
+++ b/README_tcpdevmem.md
@@ -3,6 +3,7 @@
 Table of Contents
 - [Neper with TCPDirect run instructions](#neper-with-tcpdirect-run-instructions)
   - [TCPDirect CUDA: tcp\_stream within Docker container](#tcpdirect-cuda-tcp_stream-within-docker-container)
+      - [Note on accessing Neper logs or long-running container:](#note-on-accessing-neper-logs-or-long-running-container)
     - [Building your own image for testing](#building-your-own-image-for-testing)
       - [building the image on your workstation, within the repo directory](#building-the-image-on-your-workstation-within-the-repo-directory)
       - [creating a container on the VM](#creating-a-container-on-the-vm)
@@ -19,15 +20,14 @@ Table of Contents
 
 ```
 # On COS VM, do:
-./run_neper_container.sh bash
-
-# within the container
 FLOWS=2
 BUF_SIZE=409600
 DEVS=eth1,eth2,eth3,eth4
 DSTS=192.168.1.26,192.168.2.26,192.168.3.26,192.168.4.26
 SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
-./multi_neper.py --hosts $DSTS \
+
+./run_neper_container.sh ./multi_neper.py \
+  --hosts $DSTS \
   --devices $DEVS --buffer-size $BUF_SIZE \
   --flows $FLOWS --threads $FLOWS \
   --src-ips $SRCS --log DEBUG \
@@ -36,6 +36,31 @@ SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
   --mode cuda
 ```
 
+#### Note on accessing Neper logs or long-running container:
+
+If access to the log files are required (i.e. when using `tcpd-validate` flag and checking the logs for data integrity), you can start the container, then run `multi_neper.py` so that you don't exit out of the container after the Neper run completes.
+
+```
+./run_neper_container.sh bash
+
+# within the container
+FLOWS=2
+BUF_SIZE=409600
+DEVS=eth1,eth2,eth3,eth4
+DSTS=192.168.1.26,192.168.2.26,192.168.3.26,192.168.4.26
+SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
+./multi_neper.py \
+  --hosts $DSTS \
+  --devices $DEVS --buffer-size $BUF_SIZE \
+  --flows $FLOWS --threads $FLOWS \
+  --src-ips $SRCS --log DEBUG \
+  --q-num $FLOWS --phys-len 2147483648 \
+  --client \
+  --mode cuda
+
+# grep log files
+ls | grep log
+```
 
 ### Building your own image for testing
 

--- a/README_tcpdevmem.md
+++ b/README_tcpdevmem.md
@@ -1,0 +1,277 @@
+# Neper with TCPDirect run instructions
+
+Table of Contents
+- [Neper with TCPDirect run instructions](#neper-with-tcpdirect-run-instructions)
+  - [TCPDirect CUDA: tcp\_stream within Docker container](#tcpdirect-cuda-tcp_stream-within-docker-container)
+    - [Building your own image for testing](#building-your-own-image-for-testing)
+    - [Override CUDA library directory (DLVM)](#override-cuda-library-directory-dlvm)
+  - [TCPDirect UDMA: Compiling tcp\_stream](#tcpdirect-udma-compiling-tcp_stream)
+  - [Running tcp\_stream](#running-tcp_stream)
+    - [Added flags](#added-flags)
+    - [Running tcp\_stream via `multi_neper.py`](#running-tcp_stream-via-multi_neperpy)
+      - [Example of successful output](#example-of-successful-output)
+    - [Running tcp\_stream directly](#running-tcp_stream-directly)
+
+
+## TCPDirect CUDA: tcp_stream within Docker container
+
+A TCPDirect-Cuda enabled Docker image exists at `gcr.io/a3-tcpd-staging-hostpool/neper`. The `run_neper_container.sh` script makes it easy to run Neper:
+
+
+```
+./run_neper_container.sh
+
+# within the container
+FLOWS=2
+BUF_SIZE=409600
+DEVS=eth1,eth2,eth3,eth4
+DSTS=192.168.1.26,192.168.2.26,192.168.3.26,192.168.4.26
+SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
+./multi_neper.py --hosts $DSTS \
+  --devices $DEVS --buffer-size $BUF_SIZE \
+  --flows $FLOWS --threads $FLOWS \
+  --src-ips $SRCS --log DEBUG \
+  --q-num $FLOWS --phys-len 2147483648 \
+  --client \
+  --mode cuda
+```
+
+
+
+### Building your own image for testing
+
+
+```
+# within the repo directory
+docker build -t neperc .
+
+function run_neper_container() {
+  docker run \
+    --name neper_c \
+    -u 0 --network=host \
+    --cap-add=IPC_LOCK \
+    --userns=host \
+    --volume /run/tcpx:/tmp \
+    --volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
+    --volume /var/lib/tcpx:/usr/local/tcpx \
+    --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
+    --device /dev/nvidia0:/dev/nvidia0 \
+    --device /dev/nvidia1:/dev/nvidia1 \
+    --device /dev/nvidia2:/dev/nvidia2 \
+    --device /dev/nvidia3:/dev/nvidia3 \
+    --device /dev/nvidia4:/dev/nvidia4 \
+    --device /dev/nvidia5:/dev/nvidia5 \
+    --device /dev/nvidia6:/dev/nvidia6 \
+    --device /dev/nvidia7:/dev/nvidia7 \
+    --device /dev/nvidia-uvm:/dev/nvidia-uvm \
+    --device /dev/nvidiactl:/dev/nvidiactl \
+    --cap-add=NET_ADMIN \
+    --env LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/tcpx/lib64 \
+    "$@"
+}
+
+run_neper_container -it neperc bash
+```
+
+You can replace the `neperc` image name and run `docker push ${image_name}` if you’re building the image on one host, and running a container on another.
+
+
+### Override CUDA library directory (DLVM)
+
+The script assumes that `libcuda.so*` files are found in `/var/lib/nvidia/lib64`. In case this isn’t true (like when on DLVM), you can override the default env var: `CUDA_LIB_DIR`:
+
+```
+CUDA_LIB_DIR=/usr/lib/x86_64-linux-gnu ./run_neper_container.sh
+```
+
+
+## TCPDirect UDMA: Compiling tcp_stream
+
+Neper can be built statically on a host with UDMA header files.
+
+The Makefile assumes that the header files are found at `~/cos-kernel/usr/include`. You can manually change the directory in the Makefile:
+
+
+```
+CFLAGS += -DWITH_TCPDEVMEM_UDMA -DNDEBUG=1 -static -I ~/cos-kernel/usr/include <your new directory>
+```
+
+```
+# clone the Neper repository and checkout the tcpd branch
+git clone -b tcpd https://github.com/google/neper.git
+cd neper
+make tcp_steam WITH_TCPDEVMEM_UDMA=1
+
+# copy the binary to your hosts
+scp tcp_stream root@${HOST1}:~/
+scp multi_neper.py root@${HOST1}:~/
+
+scp tcp_stream root@${HOST2}:~/
+scp multi_neper.py root@${HOST2}:~/
+```
+
+
+
+## Running tcp_stream
+
+
+### Added flags
+
+In general, these flags will be automatically populated by `multi_neper.py`.
+
+```
+--tcpd-validate     # payload validation - must pass to both Tx/Rx if enabled
+--tcpd-tcpd-rx-cpy
+--tcpd-nic-pci-addr
+--tcpd-gpu-pci-addr
+--tcpd-phys-len     # CUDA mode allows for a much larger value than UDMA mode
+--tcpd-src-ip
+--tcpd-dst-ip
+--tcpd-link-name
+--queue-start
+--queue-num
+```
+
+Running TCPDirect requires the toggling of a handful of ethtool commands on the receiver (host). If running tcp_stream via `multi_neper.py`, this will automatically be done before each run.
+
+Otherwise, it might be necessary to run these commands before each tcp_stream run.
+
+
+### Running tcp_stream via `multi_neper.py`
+
+`multi_neper.py` is a python script that runs in parallel multiple tcp_streams, which is useful when running tcp_stream across multiple pairs of NICs.
+
+The script also calls ethtool commands on the receiver (host) before spawning tcp_streams, to set the receiver into a TCPDirect-capable state.
+
+To view all of `multi_neper.py`’s accepted flags, run `multi_neper.py --help`.
+
+
+```
+# Rx (host)
+FLOWS=2
+BUF_SIZE=409600
+DEVS=eth1,eth2,eth3,eth4
+DSTS=192.168.1.26,192.168.2.26,192.168.3.26,192.168.4.26 # host IP addresses
+SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23 # client IP addresses
+./multi_neper.py --hosts $DSTS \
+  --devices $DEVS --buffer-size $BUF_SIZE \
+  --flows $FLOWS --threads $FLOWS \
+  --src-ips $SRCS --log DEBUG \
+  --q-num $FLOWS --phys-len 2147483648 \
+  --mode cuda
+
+
+# Tx (client)
+FLOWS=2
+BUF_SIZE=409600
+DEVS=eth1,eth2,eth3,eth4
+DSTS=192.168.1.26,192.168.2.26,192.168.3.26,192.168.4.26
+SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
+./multi_neper.py --hosts $DSTS \
+  --devices $DEVS --buffer-size $BUF_SIZE \
+  --flows $FLOWS --threads $FLOWS \
+  --src-ips $SRCS --log DEBUG \
+  --q-num $FLOWS --phys-len 2147483648 \
+  --client \
+  --mode cuda
+```
+
+#### Example of successful output
+
+```
+DEBUG:root:minflt_end=6037
+DEBUG:root:majflt_start=0
+DEBUG:root:majflt_end=0
+DEBUG:root:nvcsw_start=653
+DEBUG:root:nvcsw_end=675141
+DEBUG:root:nivcsw_start=2
+DEBUG:root:nivcsw_end=1018
+DEBUG:root:num_samples=155
+DEBUG:root:time_end=613529.729042674
+DEBUG:root:correlation_coefficient=1.00
+DEBUG:root:throughput=193669.32
+DEBUG:root:throughput_units=Mbit/s
+DEBUG:root:local_throughput=193669323769
+DEBUG:root:remote_throughput=0
+DEBUG:root:
+[eth1] Throughput (Mb/s): 193551.94
+[eth2] Throughput (Mb/s): 193652.69
+[eth3] Throughput (Mb/s): 193640.21
+[eth4] Throughput (Mb/s): 193669.32
+```
+
+
+
+### Running tcp_stream directly
+
+**If you’re running Neper outside of the container, make sure to run**
+
+```
+sudo -s
+```
+
+**before everything. `ethtool` commands and queue-binding is only available to superuser.**
+
+Before running tcp_stream, the ethtool commands that `multi_neper.py` runs should also be run:
+
+```
+# run as superuser, if running Neper as root
+sudo -s
+
+res_link() {
+ethtool --set-priv-flags $1 enable-strict-header-split on
+ethtool --set-priv-flags $1 enable-strict-header-split off
+ethtool --set-priv-flags $1 enable-header-split off
+ethtool --set-rxfh-indir $1 equal 16
+ethtool -K $1 ntuple off
+ethtool --set-priv-flags $1 enable-strict-header-split off
+ethtool --set-priv-flags $1 enable-header-split off
+ethtool -K $1 ntuple off
+ethtool --set-priv-flags $1 enable-max-rx-buffer-size on
+ethtool -K $1 ntuple on
+}
+
+# call on each link you plan to run tcp_stream across
+res_link eth1
+```
+
+
+You can then run `multi_neper.py` with the `--dry-run` flag, to see what tcp_stream commands the script would run:
+
+
+```
+$ FLOWS=1
+$ BUF_SIZE=409600
+$ DEVS=eth1
+$ DSTS=192.168.1.26
+$ SRCS=192.168.1.23
+$ ./multi_neper.py --hosts $DSTS \
+  --devices $DEVS --buffer-size $BUF_SIZE \
+  --flows $FLOWS --threads $FLOWS \
+  --src-ips $SRCS --log DEBUG \
+  --q-num $FLOWS --phys-len 2147483648 \
+  --client \
+  --mode cuda \
+  --dry-run
+
+DEBUG:root:running on ['eth1']
+DEBUG:root:('taskset --cpu-list 2-2 ./tcp_stream -T 1 -F 1 --port 12345 --source-port 12345 --control-port 12866 --buffer-size 409600  -l 10 --num-ports 1 --tcpd-phys-len 2147483648 --tcpd-nic-pci-addr 0000:06:00.0 --tcpd-gpu-pci-addr 0000:04:00.0 -c -H 192.168.1.26', {'CUDA_VISIBLE_DEVICES': '0', ...
+```
+
+The script will print the tcp_stream command, as well as the environment variables. The only environment variable that matters is `CUDA_VISIBLE_DEVICES` if running in `cuda` mode, which tells tcp_stream which GPU it should allocate memory on.
+
+You can then reset the receiver, and copy/paste the command:
+
+```
+# on Rx (host)
+res_link eth1
+./multi_neper.py --dry-run ${other_rx_args}
+
+CUDA_VISIBLE_DEVICES=0 ./tcp_stream # copy cmd from previous line
+
+
+# on Tx (client)
+./multi_neper.py --dry-run ${other_tx_args}
+
+CUDA_VISIBLE_DEVICES=0 ./tcp_stream # copy cmd from previous line
+```

--- a/README_tcpdevmem.md
+++ b/README_tcpdevmem.md
@@ -17,12 +17,9 @@ Table of Contents
 
 ## TCPDirect CUDA: tcp_stream within Docker container
 
-A TCPDirect-Cuda enabled Docker image exists at `gcr.io/a3-tcpd-staging-hostpool/neper`. The `run_neper_container.sh` script makes it easy to run Neper:
-
-
 ```
 # On COS VM, do:
-./run_neper_container.sh
+./run_neper_container.sh bash
 
 # within the container
 FLOWS=2
@@ -38,7 +35,6 @@ SRCS=192.168.1.23,192.168.2.23,192.168.3.23,192.168.4.23
   --client \
   --mode cuda
 ```
-
 
 
 ### Building your own image for testing
@@ -99,7 +95,7 @@ run_neper_container -it $IMAGE_NAME bash
 The script assumes that `libcuda.so*` files are found in `/var/lib/nvidia/lib64`. In case this isn’t true (like when on DLVM), you can override the default env var: `CUDA_LIB_DIR`:
 
 ```
-CUDA_LIB_DIR=/usr/lib/x86_64-linux-gnu ./run_neper_container.sh
+CUDA_LIB_DIR=/usr/lib/x86_64-linux-gnu ./run_neper_container.sh bash
 ```
 
 

--- a/run_neper_container.sh
+++ b/run_neper_container.sh
@@ -29,6 +29,7 @@ done
 function run_neper_container() {
   docker run \
     --name neper_c \
+    --rm \
     -u 0 --network=host \
     --cap-add=IPC_LOCK \
     --userns=host \
@@ -53,4 +54,4 @@ function run_neper_container() {
 
 sudo iptables -I INPUT -p tcp -m tcp -j ACCEPT
 
-run_neper_container -it "gcr.io/a3-tcpd-staging-hostpool/neper" bash
+run_neper_container -it "gcr.io/a3-tcpd-staging-hostpool/neper" $@

--- a/tcpdevmem.c
+++ b/tcpdevmem.c
@@ -9,7 +9,7 @@
 #include "tcpdevmem.h"
 #include "thread.h"
 
-#define TEST_PREFIX "ncdevmem_common"
+#define TEST_PREFIX "ncdevmem"
 
 int install_flow_steering(const struct options *opts, intptr_t buf,
 			  struct thread *t)

--- a/tcpdevmem.h
+++ b/tcpdevmem.h
@@ -4,6 +4,11 @@
 #define PAGE_SHIFT (12)
 #define PAGE_SIZE (1 << PAGE_SHIFT)
 
+#ifndef MSG_SOCK_DEVMEM
+#define MSG_SOCK_DEVMEM 0x2000000	/* don't copy devmem pages but return
+					 * them as cmsg instead */
+#endif
+
 int install_flow_steering(const struct options *opts, intptr_t buf,
 			  struct thread *t);
 int tcpd_setup_socket(int socket);

--- a/tcpdevmem_cuda.cu
+++ b/tcpdevmem_cuda.cu
@@ -1,6 +1,9 @@
+#define __iovec_defined 1
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <linux/uio.h>
 #include <asm-generic/errno-base.h>
 #include <asm-generic/socket.h>
 #include <errno.h>

--- a/tcpdevmem_cuda.cu
+++ b/tcpdevmem_cuda.cu
@@ -167,7 +167,6 @@ err_close_dmabuf:
 int tcpd_cuda_setup_alloc(const struct options *opts, void **f_mbuf, struct thread *t)
 {
   bool is_client = opts->client;
-  int ret;
   void *gpu_gen_mem_;
   int gpu_mem_fd_;
   int dma_buf_fd_;

--- a/tcpdevmem_udma.c
+++ b/tcpdevmem_udma.c
@@ -21,11 +21,6 @@
 
 #define TEST_PREFIX "ncdevmem_udma"
 
-#ifndef MSG_SOCK_DEVMEM
-#define MSG_SOCK_DEVMEM 0x2000000	/* don't copy devmem pages but return
-					 * them as cmsg instead */
-#endif
-
 int udma_setup_alloc(const struct options *opts, void **f_mbuf, struct thread *t)
 {
         bool is_client = opts->client;


### PR DESCRIPTION
**Assumes that kernel hdr files are in usr/ folder in your Neper working directory.**

Changes from git pulling tcpd branch within the container, to copying the source files from current Neper dir into the container, then building with those files.

Tested: docker build for CUDA & ran tcp_stream CUDA across 2 VMs