### PR TITLE
use neper in a container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:12
+WORKDIR /src
+RUN apt-get update && apt-get install build-essential -y
+COPY . .
+RUN make clean && make all
+
+# debug images contain a busybox shell
+FROM gcr.io/distroless/cc-debian12:debug
+WORKDIR /home
+COPY --from=0 /src/tcp_rr /bin/tcp_rr
+COPY --from=0 /src/tcp_stream /bin/tcp_stream
+COPY --from=0 /src/tcp_crr /bin/tcp_crr
+COPY --from=0 /src/udp_rr /bin/udp_rr
+COPY --from=0 /src/udp_stream /bin/udp_stream
+COPY --from=0 /src/psp_stream /bin/psp_stream
+COPY --from=0 /src/psp_crr /bin/psp_crr
+COPY --from=0 /src/psp_rr /bin/psp_rr
+# useful to deploy the image as a Kubernetes Pod
+# as it keeps the image running forever
+ENTRYPOINT [ "/busybox/sleep", "infinity" ]

--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,9 @@ binaries: tcp_rr tcp_stream tcp_crr udp_rr udp_stream psp_stream psp_crr psp_rr
 
 clean:
 	rm -f *.o tcp_rr tcp_stream tcp_crr udp_rr udp_stream psp_stream psp_crr psp_rr
+
+IMAGE ?= neper
+TAG ?= $(shell git describe --tags --always --dirty)
+
+image:
+	docker build --tag ${IMAGE}:${TAG} .


### PR DESCRIPTION
This allows to use neper in environments like kubernetes

```
make image
docker build --tag neper:2ae2467 .
Sending build context to Docker daemon    812kB
...
Step 16/16 : ENTRYPOINT [ "/busybox/sleep", "infinity" ]
 ---> Using cache
 ---> f891b1afe800
Successfully built f891b1afe800
Successfully tagged neper:2ae2467
```
