### PR TITLE
neper: new option --wait-start to delay starting client data flows

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -54,6 +54,8 @@ void check_options_common(struct options *opts, struct callbacks *cb)
               "Max pacing rate must be non-negative.");
         CHECK(cb, opts->max_pacing_rate <= UINT64_MAX,
               "Max pacing rate cannot exceed 64 bits.");
+        CHECK(cb, opts->client || (opts->wait_start == 0),
+              "The wait-start option is only valid for clients.");
 }
 
 void check_options_tcp(struct options *opts, struct callbacks *cb)

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -56,6 +56,7 @@ struct flags_parser *add_flags_common(struct flags_parser *fp)
         DEFINE_FLAG_PARSER(fp,        all_samples, parse_all_samples);
         DEFINE_FLAG(fp, bool,         time_wait,     false,    0,  "Do not set SO_LINGER 0. Close gracefully. Active peer will enter TIME_WAIT state");
         DEFINE_FLAG(fp, unsigned long, iostat_ms,    0,        0,  "Print io stats snapshot every this many ms");
+        DEFINE_FLAG(fp, unsigned long, wait_start,   0,        0,  "Wait this many seconds before starting any data flows.");
 
         /* Return the updated fp */
         return (fp);

--- a/lib.h
+++ b/lib.h
@@ -102,6 +102,7 @@ struct options {
         const char *port;
         int source_port;
         unsigned long iostat_ms;
+        unsigned long wait_start;
         const char *all_samples;
         const char secret[32]; /* includes test name */
         bool async_connect;

--- a/thread.c
+++ b/thread.c
@@ -545,6 +545,10 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
         cp = control_plane_create(opts, cb, data_pending, fn);
         control_plane_start(cp, &ai);
 
+        /* if nonzero, make the client wait before the threads are started. */
+        if (opts->client)
+                sleep(opts->wait_start);
+
         /* start threads *after* control plane is up, to reuse addrinfo. */
         reset_port(ai, atoi(opts->port), cb);
         ts = calloc(opts->num_threads, sizeof(struct thread));


### PR DESCRIPTION
This option on the client side will delay the client from creating any threads (and thus flows) after the control connection has been established. It can be useful if multiple neper server-client pairs are created over the same link, and the link gets too congested from earlier pairs for the later ones to successfully establish the control connection. The option can also be used to set up simulated packet dropping rules between making the control connection and sending traffic.

Tested:
./tcp_stream -c -H 127.0.0.1 --wait-start 5 --logtostderr
Verified that the client waited for 5 seconds before starting to send traffic.