### PR TITLE
Tcpdevmem driver reset in binary instead of multi_neper.py

### DIFF
--- a/multi_neper.py
+++ b/multi_neper.py
@@ -26,23 +26,6 @@ link_to_gpu_index = {
         "eth4": "6"
 }
 
-def run_pre_neper_cmds(dev: str):
-        cmds = [
-                f"ethtool --set-priv-flags {dev} enable-strict-header-split on",
-                f"ethtool --set-priv-flags {dev} enable-strict-header-split off",
-                f"ethtool --set-priv-flags {dev} enable-header-split off",
-                f"ethtool --set-rxfh-indir {dev} equal 16",
-                f"ethtool -K {dev} ntuple off",
-                f"ethtool --set-priv-flags {dev} enable-strict-header-split off",
-                f"ethtool --set-priv-flags {dev} enable-header-split off",
-                f"ethtool -K {dev} ntuple off",
-                f"ethtool --set-priv-flags {dev} enable-max-rx-buffer-size on",
-                f"ethtool -K {dev} ntuple on"
-        ]
-
-        for cmd in cmds:
-                subprocess.run(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-
 # returns a 2-tuple of a Neper command and a dict of env vars
 def build_neper_cmd(neper_dir: str, is_client: bool, dev: str,
                     threads: int, flows: int,
@@ -167,10 +150,6 @@ if __name__ == "__main__":
         if not args.client:
                 info("setting up flow-steering rules")
                 # src_ips = args.src_ips.split(",")
-
-                for i, dev in enumerate(devices):
-                        if not args.dry_run:
-                                run_pre_neper_cmds(dev)
 
         cmds = []
         debug(f"running on {devices}")

--- a/tcpdevmem.c
+++ b/tcpdevmem.c
@@ -10,42 +10,44 @@
 #include "thread.h"
 
 #define TEST_PREFIX "ncdevmem"
+#define RETURN_IF_NON_ZERO(cmd)	\
+	ret = (cmd);		\
+	if (ret) return ret;
 
 int driver_reset(const struct options *opts) {
 	char driver_reset_cmd[512];
 	int ret = 0;
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split on", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-header-split off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-rxfh-indir %s equal 16", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool -K %s ntuple off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-header-split off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool -K %s ntuple off", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-max-rx-buffer-size on", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
 	sprintf(driver_reset_cmd, "ethtool -K %s ntuple on", opts->tcpd_link_name);
-	ret = ret | system(driver_reset_cmd);
+	RETURN_IF_NON_ZERO(system(driver_reset_cmd));
 
-	printf("TCPDEVMEM driver reset returning %i\n", ret);
 	return ret;
 }
 

--- a/tcpdevmem.c
+++ b/tcpdevmem.c
@@ -11,6 +11,44 @@
 
 #define TEST_PREFIX "ncdevmem"
 
+int driver_reset(const struct options *opts) {
+	char driver_reset_cmd[512];
+	int ret = 0;
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split on", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-header-split off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-rxfh-indir %s equal 16", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool -K %s ntuple off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-strict-header-split off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-header-split off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool -K %s ntuple off", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool --set-priv-flags %s enable-max-rx-buffer-size on", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	sprintf(driver_reset_cmd, "ethtool -K %s ntuple on", opts->tcpd_link_name);
+	ret = ret | system(driver_reset_cmd);
+
+	printf("TCPDEVMEM driver reset returning %i\n", ret);
+	return ret;
+}
+
 int install_flow_steering(const struct options *opts, intptr_t buf,
 			  struct thread *t)
 {

--- a/tcpdevmem.h
+++ b/tcpdevmem.h
@@ -9,6 +9,7 @@
 					 * them as cmsg instead */
 #endif
 
+int driver_reset(const struct options *opts);
 int install_flow_steering(const struct options *opts, intptr_t buf,
 			  struct thread *t);
 int tcpd_setup_socket(int socket);

--- a/thread.c
+++ b/thread.c
@@ -29,6 +29,9 @@
 #include "rusage.h"
 #include "snaps.h"
 #include "stats.h"
+#if defined(WITH_TCPDEVMEM_CUDA) || defined(WITH_TCPDEVMEM_UDMA)
+#include "tcpdevmem.h"
+#endif /* WITH_TCPDEVMEM_CUDA || WITH_TCPDEVMEM_UDMA */
 #include "thread.h"
 
 #ifndef NO_LIBNUMA
@@ -366,6 +369,13 @@ void start_worker_threads(struct options *opts, struct callbacks *cb,
         LOG_INFO(cb, "Number of allowed_cores = %d", allowed_cores);
 
         int percentiles = percentiles_count(&opts->percentiles);
+
+#if defined(WITH_TCPDEVMEM_CUDA) || defined(WITH_TCPDEVMEM_UDMA)
+        /* perform driver reset (on host) in anticipation of TCPDEVMEM run */
+        if (opts->tcpd_nic_pci_addr && !opts->client) {
+                driver_reset(opts);
+        }
+#endif /* WITH_TCPDEVMEM_CUDA || WITH_TCPDEVMEM_UDMA */
 
         for (i = 0; i < opts->num_threads; i++) {
                 t[i].index = i;

--- a/thread.c
+++ b/thread.c
@@ -373,7 +373,8 @@ void start_worker_threads(struct options *opts, struct callbacks *cb,
 #if defined(WITH_TCPDEVMEM_CUDA) || defined(WITH_TCPDEVMEM_UDMA)
         /* perform driver reset (on host) in anticipation of TCPDEVMEM run */
         if (opts->tcpd_nic_pci_addr && !opts->client) {
-                driver_reset(opts);
+                if (driver_reset(opts))
+                        LOG_FATAL(cb, "TCPDEVMEM driver reset failed");
         }
 #endif /* WITH_TCPDEVMEM_CUDA || WITH_TCPDEVMEM_UDMA */
 


### PR DESCRIPTION
Tested: build Docker image and run tcp_stream in CUDA TCPDEVMEM mode across 2 VMs