### PR TITLE
minor clean-up (imports, snapshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,3 +427,10 @@ be insignificant.  However, the keys are case sensitive.
 * C99, avoid compiler-specific extensions.
 * No external dependency.
 * Linux coding style, with tabs expanded to 8 spaces.
+
+## Changelog (not comprehensive)
+
+### 2024-02-21
+
+* **Breaking**: changed histogram implementation
+* 

--- a/snaps.c
+++ b/snaps.c
@@ -23,15 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct neper_snaps {
-        struct neper_rusage *rusage;
-        int total;   /* # of snap structs allocated */
-        int count;   /* # of populated snap structs */
-        int iter;    /* iterator bookmark */
-        int extent;  /* extended size of the snap struct */
-        char *ptr;   /* storage */
-};
-
 /*
  * Compare two neper_snap structs.
  * The one with the earlier timestamp is considered to be smaller.

--- a/snaps.h
+++ b/snaps.h
@@ -52,7 +52,14 @@ void neper_snap_print(const struct neper_snap *, FILE *, double raw_thruput,
  * iter_done() Returns true once the end of the iterator has been reached.
  */
 
-struct neper_snaps;
+struct neper_snaps {
+        struct neper_rusage *rusage;
+        int total;   /* # of snap structs allocated */
+        int count;   /* # of populated snap structs */
+        int iter;    /* iterator bookmark */
+        int extent;  /* extended size of the snap struct */
+        char *ptr;   /* storage */
+};
 
 struct neper_snap *neper_snaps_add(struct neper_snaps *, const struct timespec *, uint64_t);
 int neper_snaps_count(const struct neper_snaps *);

--- a/stats.h
+++ b/stats.h
@@ -17,6 +17,8 @@
 #ifndef THIRD_PARTY_NEPER_STATS_H
 #define THIRD_PARTY_NEPER_STATS_H
 
+#include "snaps.h"
+
 #include <stdbool.h>
 #include <stdio.h>
 

--- a/stream.c
+++ b/stream.c
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "flow.h"
 #include "print.h"
+#include "snaps.h"
 #include "socket.h"
 #include "stats.h"
 #include "thread.h"
@@ -58,6 +59,7 @@ void stream_handler(struct flow *f, uint32_t events)
         struct thread *t = flow_thread(f);
         void *mbuf = flow_mbuf(f);
         int fd = flow_fd(f);
+        const struct neper_snaps *snaps;
         const struct options *opts = t->opts;
         /*
          * The actual size can be calculated with CMSG_SPACE(sizeof(struct X)),
@@ -81,6 +83,10 @@ void stream_handler(struct flow *f, uint32_t events)
 
         if (events & (EPOLLHUP | EPOLLRDHUP))
                 return flow_delete(f);
+
+        snaps = stat->snaps(stat);
+        if (neper_snaps_count(snaps) == 0)
+                stat->event(t, stat, 0, false, NULL);
 
         if (events & EPOLLIN)
                 do {


### PR DESCRIPTION
include some previously omitted header files (lint complaints)

Stream clients only take 1 snapshot, but doesn't properly return timespec start_time.
However, tries to take snapshots too many times, reducing throughput on udp_stream significantly.
Reduce it so only 2 snapshots are needed.

author: lixiaoyan@