### PR TITLE
Minor fix for resource leak when reading the /proc/stat file.

### DIFF
--- a/rusage.c
+++ b/rusage.c
@@ -38,13 +38,20 @@ static double get_aggregate_proc_stat_system_time()
         unsigned long dummy, system, irq, softirq;
         int nscan = 0;
         FILE *f = fopen("/proc/stat", "r");
-        if (f) {
-              /* Just keep the important values of the first seven */
-              nscan = fscanf(f, "cpu %lu %lu %lu %lu %lu %lu %lu",
-                 &dummy, &dummy, &system, &dummy, &dummy, &irq, &softirq);
-              fclose(f);
+
+        if (!f)
+        {
+                fprintf(stderr, "Unable to open /proc/stat!\n");
+                exit(1);
         }
-        if (nscan != 7) {
+
+        /* Just keep the important values of the first seven */
+        nscan = fscanf(f, "cpu %lu %lu %lu %lu %lu %lu %lu",
+                       &dummy, &dummy, &system, &dummy, &dummy, &irq, &softirq);
+        fclose(f); // Ensure file is closed in all cases
+
+        if (nscan != 7)
+        {
                 fprintf(stderr, "IO or parser error while reading /proc/stat!\n");
                 exit(1);
         }


### PR DESCRIPTION
# Overview

Refactored `get_aggregate_proc_stat_system_time` to close the `/proc/stat` file in all cases. Previously, if `fscanf` failed, the file was not being closed.

# References

#16 