### PR TITLE
[Fix] Prevent skipping the last latency percentile list argument

### DIFF
--- a/percentiles.c
+++ b/percentiles.c
@@ -71,7 +71,7 @@ void percentiles_parse(const char *arg, void *out, struct callbacks *cb)
                 else
                         p->p_th[++cur] = p->p_th[i];
         }
-        p->p_count = cur;
+        p->p_count = cur + 1;
 }
 
 void percentiles_print(const char *name, const void *var, struct callbacks *cb)


### PR DESCRIPTION
The current code takes a list of comma separated 'double' values representing the latency percentile data points that the user is interested in. The user might repeat a particular percentile value. To prevent printing the same percentile data point twice, the code (percentile.c) sorts the list of percentiles requested by the user, in the order of their percentile values, i.e. higher percentiles will be sorted at the end.

After sorting and removing the duplicates, the code incorrectly sets the number of the percentiles to one less than the actual count. This results in the code not printing the last percentile in the provided list of percentile arguments.

For example,
option_used_in_cmd>  -p 50.0,95.0,99.0, results in the following
stdout_results>    percentiles=50,95

This patch fixes the issue, by setting the total count of the request percentiles to the correct value.