### PR TITLE
Fixed segfault when test_length is negative.

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -177,8 +177,12 @@ struct neper_stat *neper_stat_init(struct flow *f, struct neper_histo *histo,
 {
         struct thread *t = flow_thread(f);
         const struct options *opts = t->opts;
-        const int n = (opts->test_length / opts->interval) + 1;
-
+        int n;
+        // test_length, >0 seconds, <0 transactions.
+        if (opts->test_length < 0)
+                n = -opts->test_length + 1;
+        else
+                n = (opts->test_length / opts->interval) + 1;
         struct stat_impl *impl =
                 calloc_or_die(1, sizeof(struct stat_impl), t->cb);
         struct neper_stat *stat = &impl->stat;

--- a/thread.c
+++ b/thread.c
@@ -531,7 +531,7 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
                 data_pending = NULL;
         } else {
                 PRINT(cb, "total_transactions", "%d", -(opts->test_length));
-                data_pending = calloc(1, sizeof(*data_pending));
+                data_pending = calloc(1, sizeof(struct countdown_cond));
                 countdown_cond_init(data_pending, -(opts->test_length));
         }
         if (opts->dry_run)


### PR DESCRIPTION
For tcp_rr/tcp_stream (and other binaries), --test-length flag can be negative to mean transaction numbers. (See: define_all_flags.c)

However, not all code paths correctly handles this negative number, which leads to a negative size number passed to alloc.

This PR also fixed a nit - replacing "sizeof(*a_null_pointer)" with "sizeof(the type that the pointer points to)".  (Dereferencing a null pointer is always sth to avoid)

Tested:
  build the binary and manually run it on workstation and devrez machines with --test-length=-600000