### PR TITLE
add ns/us/ms/s suffixes to --delay

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -19,7 +19,7 @@
 
 void check_options_common(struct options *opts, struct callbacks *cb)
 {
-	FILE *f;
+        FILE *f;
 
         /* Check the options shared by ALL main programs */
         CHECK(cb, !(opts->logtostderr && opts->nolog),
@@ -40,14 +40,14 @@ void check_options_common(struct options *opts, struct callbacks *cb)
               "local_hosts may only be set for clients.");
         CHECK(cb, opts->interval > 0,
               "Interval must be positive.");
-	if ((f = fopen(PROCFILE_SOMAXCONN, "r")) != NULL) {
-		int result = 0;
-		if (fscanf(f, "%d", &result) != 1)
-			PLOG_FATAL(cb, "fscanf");
-		fclose(f);
-		CHECK(cb, opts->listen_backlog <= result,
-		      "listen() backlog cannot exceed " PROCFILE_SOMAXCONN);
-	}
+        if ((f = fopen(PROCFILE_SOMAXCONN, "r")) != NULL) {
+                int result = 0;
+                if (fscanf(f, "%d", &result) != 1)
+                        PLOG_FATAL(cb, "fscanf");
+                fclose(f);
+                CHECK(cb, opts->listen_backlog <= result,
+                      "listen() backlog cannot exceed " PROCFILE_SOMAXCONN);
+        }
         CHECK(cb, opts->maxevents >= 1,
               "Number of epoll events must be positive.");
         CHECK(cb, opts->max_pacing_rate >= 0,
@@ -115,11 +115,11 @@ void check_options_udp_stream(struct options *opts, struct callbacks *cb)
 
 void check_options_psp_common(struct options *opts, struct callbacks *cb)
 {
-	if (opts->client) {
-		CHECK(cb, opts->local_hosts != NULL,
-		      "PSP client requires local IP (-L) for device lookup.");
-	} else {
-		CHECK(cb, opts->host != NULL,
-		      "PSP server requires server IP (-H) for device lookup.");
-	}
+        if (opts->client) {
+                CHECK(cb, opts->local_hosts != NULL,
+                      "PSP client requires local IP (-L) for device lookup.");
+        } else {
+                CHECK(cb, opts->host != NULL,
+                      "PSP server requires server IP (-H) for device lookup.");
+        }
 }

--- a/control_plane.c
+++ b/control_plane.c
@@ -315,7 +315,7 @@ static void ctrl_notify_server(int ctrl_conn, int magic, uint64_t result,
         struct hs_msg msg = { .magic = htonl(magic), .type = htonl(CLI_DONE),
                                 .remote_rate = htobe64(result) };
         LOG_INFO(cb, "+++ CLI --> SER   CLI_DONE rate %" PRIu64,
-		 be64toh(msg.remote_rate));
+                 be64toh(msg.remote_rate));
         send_msg(ctrl_conn, &msg, cb, __func__);
         if (shutdown(ctrl_conn, SHUT_WR))
                 PLOG_ERROR(cb, "shutdown");
@@ -427,7 +427,7 @@ void control_plane_wait_until_done(struct control_plane *cp, struct thread *t)
 {
         struct print_io_stats_info s = {
                 .cb = cp->cb, .t = t, .num_threads = cp->opts->num_threads,
-		.start_ns = clock_now(), .prev_ns = clock_now()};
+                .start_ns = clock_now(), .prev_ns = clock_now()};
         if (cp->opts->client) {
                 if (cp->opts->test_length > 0) {
                         signal(SIGALRM, sig_alarm_handler);
@@ -484,7 +484,7 @@ void control_plane_stop(struct control_plane *cp)
                 if (recv_msg(cp->ctrl_conn, &msg, cp->cb, __func__))
                         LOG_FATAL(cp->cb, "Final handshake mismatch");
                 LOG_INFO(cp->cb, "+++ CLI <-- SER   SER_BYE rate %" PRIu64,
-			 be64toh(msg.remote_rate));
+                         be64toh(msg.remote_rate));
                 ((struct options *)cp->opts)->remote_rate = be64toh(msg.remote_rate);
                 do_close(cp->ctrl_conn);
         } else {

--- a/countdown_cond.h
+++ b/countdown_cond.h
@@ -56,39 +56,39 @@
  */
 
 struct countdown_cond {
-	int value;
-	int wait;
+        int value;
+        int wait;
 };
 
 static inline void countdown_cond_init(struct countdown_cond *cc, int v)
 {
-	 cc->value = v;
-	 cc->wait = v;
+        cc->value = v;
+        cc->wait = v;
 }
 
 static inline int countdown_cond_dec(const struct countdown_cond *cc)
 {
-	 return __sync_add_and_fetch((int *)&cc->value, -1);
+        return __sync_add_and_fetch((int *)&cc->value, -1);
 }
 
 static inline int countdown_cond_commit(//struct callbacks *cb,
-				    const struct countdown_cond *cc)
+                                    const struct countdown_cond *cc)
 {
-	int value = __sync_add_and_fetch((int *)&cc->wait, -1);
+        int value = __sync_add_and_fetch((int *)&cc->wait, -1);
 
-	if (value == 0)
-		futex(&cc->wait, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
-	if (value >= 0)
-		return value;
+        if (value == 0)
+                futex(&cc->wait, FUTEX_WAKE, INT_MAX, NULL, NULL, 0);
+        if (value >= 0)
+                return value;
 
-	//PLOG_FATAL(cb, "countdown_inc() value underflow %d", value);
-	return -1;
+        //PLOG_FATAL(cb, "countdown_inc() value underflow %d", value);
+        return -1;
 }
 
 static inline void countdown_cond_wait(struct countdown_cond *cc)
 {
-	while (cc->wait > 0)
-		futex(&cc->wait, FUTEX_WAIT, cc->value, NULL, NULL, 0);
+        while (cc->wait > 0)
+                futex(&cc->wait, FUTEX_WAIT, cc->value, NULL, NULL, 0);
 }
 
 #endif

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -118,7 +118,8 @@ struct flags_parser *add_flags_stream(struct flags_parser *fp)
 struct flags_parser *add_flags_tcp_rr(struct flags_parser *fp)
 {
         /* Define flags specialized to only TCP_RR */
-        DEFINE_FLAG(fp, unsigned long, delay,           0,       'D', "Nanosecond delay between each send()/write()");
+        DEFINE_FLAG(fp, unsigned long, delay,           0,       'D', "Delay between each send()/write() in ns (default), us, ms, or s");
+        DEFINE_FLAG_PARSER(fp,         delay, parse_duration);
         DEFINE_FLAG(fp, bool,          async_connect,   false,   0,  "use non blocking connect");
 
         /* Return the updated fp */

--- a/logging.c
+++ b/logging.c
@@ -214,23 +214,23 @@ static void logtonull()
 
 void logging_init(struct callbacks *cb, int argc, char **argv)
 {
-	/*
-	 * Quickly scan options, if we have --logtostderr or --nolog,
-	 * no need to create a logfile.
-	 */
-	int i;
-	for (i = 1; i < argc; i++) {
-		if (!strcmp(argv[i], "--logtostderr")) {
-			log_file = stderr;
-			break;
-		}
-		if (!strcmp(argv[i], "--nolog")) {
-			logtonull();
-			break;
-		}
-	}
-	if (!log_file)
-		open_log();
+        /*
+         * Quickly scan options, if we have --logtostderr or --nolog,
+         * no need to create a logfile.
+         */
+        int i;
+        for (i = 1; i < argc; i++) {
+                if (!strcmp(argv[i], "--logtostderr")) {
+                        log_file = stderr;
+                        break;
+                }
+                if (!strcmp(argv[i], "--nolog")) {
+                        logtonull();
+                        break;
+                }
+        }
+        if (!log_file)
+                open_log();
         cb->logger = NULL;
         cb->print = print;
         cb->log_fatal = log_fatal;

--- a/parse.h
+++ b/parse.h
@@ -20,5 +20,6 @@
 void parse_all_samples(const char *arg, void *out, struct callbacks *cb);
 void parse_max_pacing_rate(const char *arg, void *out, struct callbacks *cb);
 void parse_unit(const char *arg, void *out, struct callbacks *);
+void parse_duration(const char *arg, void *out, struct callbacks *cb);
 
 #endif

--- a/psp_lib.c
+++ b/psp_lib.c
@@ -223,7 +223,7 @@ void psp_pre_connect(struct thread *t, int s, struct addrinfo *ai)
         LOG_INFO(t->cb, "waiting for km reply");
         count = read(kmfd, &resp, sizeof(resp));
         if (count == 0) {
-		LOG_FATAL(t->cb, "EOF on key management socket");
+                LOG_FATAL(t->cb, "EOF on key management socket");
         } else if (count != sizeof(resp)) {
                 LOG_FATAL(t->cb, "Short read of key reply");
         }

--- a/snaps.c
+++ b/snaps.c
@@ -58,7 +58,7 @@ static struct neper_snap *snaps_get(const struct neper_snaps *impl, int i)
                         fprintf(stderr, "Test longer than expected (%d), "
                                 "use -l <duration> to extend\n",
                                 i + reported++);
-		}
+                }
                 i = impl->total; /* point to spare element */
         }
 

--- a/socket.c
+++ b/socket.c
@@ -45,8 +45,8 @@ static void socket_init_not_established(struct thread *t, int s)
 
         if (opts->debug)
                 set_debug(s, 1, cb);
-	if (opts->mark)
-		set_mark(s, opts->mark, cb);
+        if (opts->mark)
+                set_mark(s, opts->mark, cb);
         if (opts->reuseaddr)
                 set_reuseaddr(s, 1, cb);
         if (opts->freebind)
@@ -74,7 +74,7 @@ static void socket_init_established(struct thread *t, int s)
         struct callbacks *cb = t->cb;
 
         if (opts->max_pacing_rate) {
-		/* kernels before 5.10 will silently truncate to 32 bits */
+                /* kernels before 5.10 will silently truncate to 32 bits */
                 uint64_t m = opts->max_pacing_rate;
                 setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &m, sizeof(m));
         }


### PR DESCRIPTION
You can still pass naked numbers e.g. "999" that will be interpreted as nanoseconds, but above suffixes are also now supported.

Counting out zeroes is a huge nuisance, this makes neper a little more usable.