### PR TITLE
add .log files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.log
 tcp_crr
 tcp_rr
 tcp_stream


### PR DESCRIPTION
Log files are created by default and don't need to be tracked.