### PR TITLE
Fix minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ hopefully should make individual tests more independent from each other.
 
 Optionally, a negative value for "-l, --test-length", a la netperf, can be
 specified where the absolute value is used for rr test to specify the number of
-transactions instead of time.  The transacions are distributed across flows on
+transactions instead of time.  The transactions are distributed across flows on
 demand.  Note, the "-s, --suicide-length" option can be used to specify a time
 limit.  Also, the negative value isn't currently supported for all tests, e.g.
 stream test, support for tests other than rr maybe added in the future.
@@ -433,4 +433,3 @@ be insignificant.  However, the keys are case sensitive.
 ### 2024-02-21
 
 * **Breaking**: changed histogram implementation
-* 


### PR DESCRIPTION
Corrected a misspelling of "transactions" in the "Basic usage" section. Removed an empty bullet point from the "Changelog" section for clarity.

Output: