### PR TITLE
TCP RX zerocopy

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -68,6 +68,8 @@ void check_options_tcp(struct options *opts, struct callbacks *cb)
                         "Source ports need to be in the range of 1..0xFFFF. "
                         "Best larger than 1024.");
         }
+        CHECK(cb, !(opts->rx_zerocopy && opts->skip_rx_copy),
+              "TCP RX zerocopy is not supported in conjunction RX copy skip.");
 }
 
 void check_options_udp(struct options *opts, struct callbacks *cb)

--- a/common.c
+++ b/common.c
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-#include <ctype.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
 
 #include "common.h"
-#include "hexdump.h"
-#include "parse.h"
+#include "lib.h"
+#include "logging.h"
+#include "or_die.h"
 
 #define kilo (1000)
 #define kibi (1024)

--- a/common.c
+++ b/common.c
@@ -187,7 +187,7 @@ void set_reuseaddr(int fd, int on, struct callbacks *cb)
                 PLOG_ERROR(cb, "setsockopt(SO_REUSEADDR)");
 }
 
-void set_zerocopy(int fd, int on, struct callbacks *cb)
+void set_tx_zerocopy(int fd, int on, struct callbacks *cb)
 {
 #ifndef SO_ZEROCOPY
 #define SO_ZEROCOPY 60

--- a/common.h
+++ b/common.h
@@ -152,7 +152,7 @@ struct addrinfo **parse_local_hosts(const struct options *opts, int n,
 void set_reuseport(int fd, struct callbacks *cb);
 void set_nonblocking(int fd, struct callbacks *cb);
 void set_reuseaddr(int fd, int on, struct callbacks *cb);
-void set_zerocopy(int fd, int on, struct callbacks *cb);
+void set_tx_zerocopy(int fd, int on, struct callbacks *cb);
 void set_freebind(int fd, struct callbacks *cb);
 void set_debug(int fd, int onoff, struct callbacks *cb);
 void set_mark(int fd, int mark, struct callbacks *cb);

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -106,7 +106,7 @@ struct flags_parser *add_flags_stream(struct flags_parser *fp)
         DEFINE_FLAG(fp, int,           test_length,     10,      'l', "Test length in seconds");
         DEFINE_FLAG(fp, bool,          edge_trigger,    false,   'E', "Edge-triggered epoll");
         DEFINE_FLAG(fp, bool,          reuseaddr,       false,   'R', "Use SO_REUSEADDR on sockets");
-        DEFINE_FLAG(fp, bool,          zerocopy,        false,   'Z', "Set MSG_ZEROCOPY when sending");
+        DEFINE_FLAG_NAMED(fp, bool,    tx_zerocopy,     false, "zerocopy", 'Z', "Set MSG_ZEROCOPY when sending");
         DEFINE_FLAG(fp, const struct rate_conversion *, throughput_opt, neper_units_mb_pointer_hack, 0, "Units to display for throughput");
         DEFINE_FLAG_PARSER(fp,                          throughput_opt, parse_unit);
         DEFINE_FLAG_PRINTER(fp,                         throughput_opt, print_unit);

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -143,6 +143,7 @@ struct flags_parser *add_flags_tcp_stream(struct flags_parser *fp)
         DEFINE_FLAG(fp, unsigned long, delay,           0,       'D', "Nanosecond delay between each send()/write()");
         DEFINE_FLAG(fp, int,           buffer_size,     16384,   'B', "Number of bytes that each read/write uses as the buffer");
         DEFINE_FLAG(fp, bool,          skip_rx_copy,    false,    0,  "Skip kernel->user payload copy on receives");
+        DEFINE_FLAG(fp, bool,          rx_zerocopy,     false,   'z', "Use TCP RX zerocopy");
         DEFINE_FLAG(fp, bool,          enable_read,     false,   'r', "Read from flows? enabled by default for the server");
         DEFINE_FLAG(fp, bool,          enable_write,    false,   'w', "Write to flows? Enabled by default for the client");
         DEFINE_FLAG(fp, bool,          split_bidir ,    false,    0,  "Bidirectional using separate tx/rx sockets");

--- a/flags.h
+++ b/flags.h
@@ -39,15 +39,30 @@ void flags_parser_run(struct flags_parser *fp, int argc, char **argv);
 void flags_parser_dump(struct flags_parser *fp);
 void flags_parser_destroy(struct flags_parser *fp);
 
-#define DEFINE_FLAG(FP, TYPE, VAR, DEFAULT_VALUE, SHORT_NAME, USAGE) \
-  do {                                                               \
-    TYPE default_value = DEFAULT_VALUE;                              \
-    struct options *opts = flags_parser_opts(FP);                    \
-    opts->VAR = default_value;                                       \
-    flags_parser_add(FP, SHORT_NAME, #VAR,                           \
-                     USAGE " (default " #DEFAULT_VALUE ")", #TYPE,   \
-                     &opts->VAR);                                    \
-  } while (0)
+/* You probably want DEFINE_FLAG or DEFINE_FLAG_NAMED instead of this. This
+ * macro takes extra arguments -- separating TYPE and TYPESTR -- because the
+ * preprocessor will convert a TYPE of "bool" too "_Bool" *except* in the
+ * specific case where the macro contains #TYPE. This was not fun to debug.
+ */
+#define DEFINE_FLAG_NAMED_TYPED(FP, TYPE, TYPESTR, VAR, DEFAULT_VALUE, NAME,  \
+                SHORT_NAME, USE)                                              \
+        do {                                                                  \
+                TYPE default_value = DEFAULT_VALUE;                           \
+                struct options *opts = flags_parser_opts(FP);                 \
+                opts->VAR = default_value;                                    \
+                flags_parser_add(FP, SHORT_NAME, NAME,                        \
+                                USE " (default " #DEFAULT_VALUE ")", TYPESTR, \
+                                &opts->VAR);                                  \
+        } while (0);
+
+/* DEFINE_FLAG_NAMED is like DEFINE_FLAG, but uses a custom flag name. */
+#define DEFINE_FLAG_NAMED(FP, TYPE, VAR, DEFAULT_VALUE, NAME, SHORT_NAME, USE) \
+        DEFINE_FLAG_NAMED_TYPED(FP, TYPE, #TYPE, VAR, DEFAULT_VALUE, NAME,     \
+                        SHORT_NAME, USE)
+
+#define DEFINE_FLAG(FP, TYPE, VAR, DEFAULT_VALUE, SHORT_NAME, USAGE)       \
+        DEFINE_FLAG_NAMED_TYPED(FP, TYPE, #TYPE, VAR, DEFAULT_VALUE, #VAR, \
+                        SHORT_NAME, USAGE)
 
 #define DEFINE_FLAG_PARSER(FP, VAR, PARSER) do { \
         struct options *opts = flags_parser_opts(FP); \

--- a/flow.c
+++ b/flow.c
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
+#include <linux/tcp.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <sys/mman.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "flow.h"
+#include "logging.h"
 #include "socket.h"
-#include "thread.h"
 #include "stats.h"
+#include "thread.h"
 
 /*
  * We define the flow struct locally to this file to force outside users to go

--- a/flow.c
+++ b/flow.c
@@ -357,6 +357,7 @@ ssize_t flow_recv_zerocopy(struct flow *f, void *copybuf, size_t copybuf_len) {
 
         /* Handle zerocopy data. */
         if (zc.length) {
+                flow_thread(f)->io_stats.rx_zc_bytes += zc.length;
                 madvise(f->f_rx_zerocopy_buffer, zc.length, MADV_DONTNEED);
         }
 

--- a/flow.h
+++ b/flow.h
@@ -56,9 +56,15 @@ struct flow_create_args {
         struct neper_stat *(*stat)(struct flow *); /* stats callback */
 };
 
-void flow_create(const struct flow_create_args *);
+struct flow *flow_create(const struct flow_create_args *);
 void flow_delete(struct flow *);
 /* Adds duration to f's next event time. */
 void flow_update_next_event(struct flow *f, uint64_t duration);
+
+/* Initialize RX zerocopy state for a flow. */
+void flow_init_rx_zerocopy(struct flow *f, int buffer_size,
+                          struct callbacks *cb);
+/* Perform a zerocopy receive. */
+ssize_t flow_recv_zerocopy(struct flow *f, void *copybuf, size_t copybuf_len);
 
 #endif

--- a/lib.h
+++ b/lib.h
@@ -93,6 +93,7 @@ struct options {
         bool tcp_fastopen;
         bool skip_rx_copy;
         bool tx_zerocopy;
+        bool rx_zerocopy;
         bool time_wait;
         double interval;
         long long max_pacing_rate;

--- a/lib.h
+++ b/lib.h
@@ -92,7 +92,7 @@ struct options {
         bool freebind;
         bool tcp_fastopen;
         bool skip_rx_copy;
-        bool zerocopy;
+        bool tx_zerocopy;
         bool time_wait;
         double interval;
         long long max_pacing_rate;

--- a/psp_stream_main.c
+++ b/psp_stream_main.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 
         if (opts.skip_rx_copy)
                 opts.recv_flags = MSG_TRUNC;
-        if (opts.zerocopy)
+        if (opts.tx_zerocopy)
                 opts.send_flags = MSG_ZEROCOPY;
 
         flags_parser_dump(fp);

--- a/rr.c
+++ b/rr.c
@@ -101,7 +101,11 @@ static ssize_t rr_fn_recv(struct flow *f, char *buf, size_t len)
         struct thread *t = flow_thread(f);
         ssize_t ret;
 
-        ret = recv(flow_fd(f), buf, len, 0);
+        if (t->opts->rx_zerocopy) {
+                ret = flow_recv_zerocopy(f, buf, len);
+	} else {
+		ret = recv(flow_fd(f), buf, len, 0);
+	}
         t->io_stats.rx_ops++;
         t->io_stats.rx_bytes += ret > 0 ? ret : 0;
         return ret;

--- a/socket.c
+++ b/socket.c
@@ -51,8 +51,8 @@ static void socket_init_not_established(struct thread *t, int s)
                 set_reuseaddr(s, 1, cb);
         if (opts->freebind)
                 set_freebind(s, cb);
-        if (opts->zerocopy)
-                set_zerocopy(s, 1, cb);
+        if (opts->tx_zerocopy)
+                set_tx_zerocopy(s, 1, cb);
         if (opts->client && !opts->time_wait) {
                 struct linger l;
                 l.l_onoff = 1;

--- a/tcp_stream_main.c
+++ b/tcp_stream_main.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
 
         if (opts.skip_rx_copy)
                 opts.recv_flags = MSG_TRUNC;
-        if (opts.zerocopy)
+        if (opts.tx_zerocopy)
                 opts.send_flags = MSG_ZEROCOPY;
 
         flags_parser_dump(fp);

--- a/thread.c
+++ b/thread.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <errno.h>
 #include <sched.h>
 #include <stdint.h>
 #include <sys/epoll.h>
@@ -26,6 +25,7 @@
 #include "cpuinfo.h"
 #include "flow.h"
 #include "histo.h"
+#include "logging.h"
 #include "loop.h"
 #include "percentiles.h"
 #include "pq.h"
@@ -660,6 +660,27 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
         int ret = fn->fn_report(ts);
         control_plane_stop(cp);
         control_plane_destroy(cp);
+
+        if (opts->rx_zerocopy) {
+                uint64_t total_rx_zc_bytes = 0;
+                uint64_t total_rx_bytes = 0;
+                uint64_t percent_mmaped;
+
+                for (int i = 0; i < opts->num_threads; i++) {
+                        total_rx_zc_bytes += ts[i].io_stats.rx_zc_bytes;
+                        total_rx_bytes += ts[i].io_stats.rx_bytes;
+                }
+                percent_mmaped = 100 * total_rx_zc_bytes / total_rx_bytes;
+                PRINT(cb, "bytes_mmaped", "%lu", total_rx_zc_bytes);
+                PRINT(cb, "percent_mmaped", "%lu", percent_mmaped);
+                if (percent_mmaped < 10) {
+                        LOG_WARN(cb, "Little traffic is being handled by "
+                                        "mmap. Is your MTU set appropriately "
+                                        "(4KiB + headers), and is your sender "
+                                        "using TX zerocopy (MSG_ZEROCOPY)?\n");
+                }
+        }
+
         PRINT(cb, "local_throughput", "%lld", opts->local_rate);
         PRINT(cb, "remote_throughput", "%lld", opts->remote_rate);
 

--- a/thread.h
+++ b/thread.h
@@ -90,6 +90,9 @@ struct io_stats {
         uint64_t tx_bytes;
         uint64_t rx_ops;
         uint64_t rx_bytes;
+
+        /* Counters for RX zerocopy */
+        uint64_t rx_zc_bytes;
 };
 
 typedef int (*poll_wait)(int epfd, struct epoll_event *events, int maxevents,

--- a/udp_stream_main.c
+++ b/udp_stream_main.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         else
                 opts.enable_read = true;
 
-        if (opts.zerocopy)
+        if (opts.tx_zerocopy)
                 opts.send_flags = MSG_ZEROCOPY;
 
         flags_parser_dump(fp);


### PR DESCRIPTION
While we have some support for TCP TX zerocopy via MSG_ZEROCOPY, there is no support for TCP_ZEROCOPY_RECEIVE. This patchset adds that support.