### PR TITLE
fix divide by zero error

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -662,16 +662,17 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
         control_plane_destroy(cp);
 
         if (opts->rx_zerocopy) {
-                uint64_t total_rx_zc_bytes = 0;
-                uint64_t total_rx_bytes = 0;
-                uint64_t percent_mmaped;
+                uint64_t total_zc_bytes = 0;
+                uint64_t total_bytes = 0;
+                uint64_t percent_mmaped = 0;
 
                 for (int i = 0; i < opts->num_threads; i++) {
-                        total_rx_zc_bytes += ts[i].io_stats.rx_zc_bytes;
-                        total_rx_bytes += ts[i].io_stats.rx_bytes;
+                        total_zc_bytes += ts[i].io_stats.rx_zc_bytes;
+                        total_bytes += ts[i].io_stats.rx_bytes;
                 }
-                percent_mmaped = 100 * total_rx_zc_bytes / total_rx_bytes;
-                PRINT(cb, "bytes_mmaped", "%lu", total_rx_zc_bytes);
+                if (total_zc_bytes > 0)
+                        percent_mmaped = 100 * total_zc_bytes / total_bytes;
+                PRINT(cb, "bytes_mmaped", "%lu", total_zc_bytes);
                 PRINT(cb, "percent_mmaped", "%lu", percent_mmaped);
                 if (percent_mmaped < 10) {
                         LOG_WARN(cb, "Little traffic is being handled by "


### PR DESCRIPTION
tcp_stream clients don't receive any payload, and so would try to divide by zero when used with --rx-zerocopy.

Renames a few local variables to avoid line splitting.