### PR TITLE
Avoid ephemeral port exhaustion when binding to a specific IP

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -327,6 +327,9 @@ int socket_connect_one(struct thread *t, int flags)
         socket_init_not_established(t, s);
         if (t->local_hosts) {
                 int i = (t->flow_first + t->flow_count) % t->num_local_hosts;
+		int enable = 1;
+                setsockopt(s, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &enable,
+                           sizeof(enable));
                 bind_or_die(s, t->local_hosts[i], t->cb);
         }
         if (t->fn->fn_pre_connect) {


### PR DESCRIPTION
This is edumazet's patch.

The network client was binding to a specific IP address without using `IP_BIND_ADDRESS_NO_PORT`. This forces the kernel to allocate an exclusive ephemeral port for each connection before `connect()`, leading to "Address already in use" errors when many concurrent connections are attempted (around 60k flows).

This commit adds a `setsockopt` call with `IP_BIND_ADDRESS_NO_PORT` before the `bind` call. This allows the kernel to defer port selection until `connect()`, enabling the client to establish many more concurrent connections without exhausting the ephemeral port range.

Tested:
  * Verified with strace that `IP_BIND_ADDRESS_NO_PORT` is called before bind.