### PR TITLE
Revert "add --reuseaddr to rr binaries"

### DIFF
--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -93,9 +93,8 @@ struct flags_parser *add_flags_rr(struct flags_parser *fp)
         DEFINE_FLAG(fp, struct percentiles,  percentiles,   {},                      'p', "Set reported latency percentiles (list)");
         DEFINE_FLAG_PARSER(fp,               percentiles, percentiles_parse);
         DEFINE_FLAG_PRINTER(fp,              percentiles, percentiles_print);
-        DEFINE_FLAG(fp, int,  test_length, 10,    'l', "Test length, >0 seconds, <0 transactions");
-        DEFINE_FLAG(fp, int,  buffer_size, 65536, 'B', "Number of bytes that each read()/send() can transfer at once");
-        DEFINE_FLAG(fp, bool, reuseaddr,   false, 'R', "Use SO_REUSEADDR on sockets");
+        DEFINE_FLAG(fp, int,                 test_length,   10,                      'l', "Test length, >0 seconds, <0 transactions");
+        DEFINE_FLAG(fp, int,                 buffer_size,   65536,                   'B', "Number of bytes that each read()/send() can transfer at once");
 
         /* Return the updated fp */
         return (fp);


### PR DESCRIPTION
Reverts google/neper#88

"-R " shortname is already being used in tcp_rr for response_size. 

```
-R, --reuseaddr                  Use SO_REUSEADDR on sockets (default 0)
-R, --response-size              Number of bytes in a response from server to client (default 1)
```
