### PR TITLE
Fix integer overflow in neper latency histogram calculation

### DIFF
--- a/histo.c
+++ b/histo.c
@@ -144,7 +144,8 @@ static void histo_all_finalize(struct neper_histo *impl)
 {
         const struct percentiles *pc = &impl->thread->opts->percentiles;
         double cent = impl->all_count / 100.0;
-        int sub = 0, v = 0, i;
+        int v = 0, i;
+        uint64_t sub = 0;
 
         if (!impl->first_all)
                 return;
@@ -161,7 +162,8 @@ static void histo_one_finalize(struct neper_histo *impl)
 {
         const struct percentiles *pc = &impl->thread->opts->percentiles;
         double cent = impl->one_count / 100.0;
-        int sub = 0, v = 0, i;
+        int v = 0, i;
+        uint64_t sub = 0;
 
         for (i = impl->one_min_index; i <= impl->one_max_index; i++) {
                 int n = impl->cur_buckets[i];

--- a/rr.c
+++ b/rr.c
@@ -24,6 +24,7 @@
  * as sending a message, opening a socket connection, or gathering statistics.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "coef.h"
@@ -523,7 +524,7 @@ fn_add(struct neper_stat *stat, void *ptr)
 }
 
 static void rr_log_rtt(struct thread *tinfo, struct callbacks *cb,
-                       int num_transactions)
+                       uint64_t num_transactions)
 {
         const char *sep = " ";
         const char *ext = strrchr(tinfo[0].opts->log_rtt, '.');
@@ -565,7 +566,7 @@ static void rr_log_rtt(struct thread *tinfo, struct callbacks *cb,
 
         if (transactions_logged < num_transactions) {
                 LOG_INFO(cb,
-                         "rtt_transactions_logged (%ld) < num_transactions (%d)",
+                         "rtt_transactions_logged (%ld) < num_transactions (%lu)",
                          transactions_logged, num_transactions);
         }
 }
@@ -581,8 +582,8 @@ int rr_report_stats(struct thread *tinfo)
         if (opts->nostats)
                 return 0;
 
-        int num_events = thread_stats_events(tinfo);
-        PRINT(cb, "num_transactions", "%d", num_events);
+        uint64_t num_events = thread_stats_events(tinfo);
+        PRINT(cb, "num_transactions", "%lu", num_events);
 
         if (opts->client && tinfo[0].opts->log_rtt)
                 rr_log_rtt(tinfo, cb, num_events);

--- a/thread.c
+++ b/thread.c
@@ -142,10 +142,11 @@ thread_store_flow_or_die(struct thread *ts, struct flow *f) {
 
 /* Return the total number of events across all threads.  */
 
-int thread_stats_events(const struct thread *ts)
+uint64_t thread_stats_events(const struct thread *ts)
 {
         const struct options *opts = ts[0].opts;
-        int i, sum = 0;
+        int i;
+        uint64_t sum = 0;
 
         for (i = 0; i < opts->num_threads; i++) {
                 struct neper_stats *stats = ts[i].stats;
@@ -156,10 +157,11 @@ int thread_stats_events(const struct thread *ts)
 
 /* Return the total number of snapshots across all threads. */
 
-int thread_stats_snaps(const struct thread *ts)
+uint64_t thread_stats_snaps(const struct thread *ts)
 {
         const struct options *opts = ts[0].opts;
-        int i, sum = 0;
+        int i;
+        uint64_t sum = 0;
 
         for (i = 0; i < opts->num_threads; i++) {
                 struct neper_stats *stats = ts[i].stats;
@@ -211,11 +213,11 @@ struct neper_pq *thread_stats_pq(struct thread *ts)
         struct callbacks *cb = ts[0].cb;
         int i;
 
-        int num_snaps = thread_stats_snaps(ts);
-        PRINT(cb, "num_samples", "%d", num_snaps);
+        uint64_t num_snaps = thread_stats_snaps(ts);
+        PRINT(cb, "num_samples", "%lu", num_snaps);
         if (num_snaps < 2) {
                 LOG_ERROR(cb, "insufficient number of samples, "
-                          "needed 2 or more, got %d", num_snaps);
+                          "needed 2 or more, got %lu", num_snaps);
                 return NULL;
         }
 

--- a/thread.h
+++ b/thread.h
@@ -138,8 +138,8 @@ struct thread {
         long rtt_log_capacity;
 };
 
-int thread_stats_events(const struct thread *);
-int thread_stats_snaps(const struct thread *);
+uint64_t thread_stats_events(const struct thread *);
+uint64_t thread_stats_snaps(const struct thread *);
 void thread_init_noburst(struct thread *);
 
 /* Reserves and returns the next available timeslot based on the noburst rate


### PR DESCRIPTION
Long tcp_rr tests with high flows cause an overflow in the histogram calculations, which manifests as latency percentiles being reported as zero

Using uint64_t fixes it.