### PR TITLE
disable clang format

### DIFF
--- a/check_all_options.c
+++ b/check_all_options.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "check_all_options.h"
 
@@ -132,3 +134,4 @@ void check_options_psp_common(struct options *opts, struct callbacks *cb)
                       "PSP server requires server IP (-H) for device lookup.");
         }
 }
+/* clang-format on */

--- a/check_all_options.h
+++ b/check_all_options.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_CHECK_ALL_OPTIONS_H_
 #define THIRD_PARTY_NEPER_CHECK_ALL_OPTIONS_H_
 
@@ -34,3 +36,4 @@ void check_options_psp_common(struct options *opts, struct callbacks *cb);
 
 #endif  // THIRD_PARTY_NEPER_CHECK_ALL_OPTIONS_H_
 
+/* clang-format on */

--- a/coef.c
+++ b/coef.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "coef.h"
 #include "common.h"
 
@@ -102,3 +104,4 @@ struct neper_coef *neper_coef(void)
 
         return coef;
 }
+/* clang-format on */

--- a/coef.h
+++ b/coef.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_COEF_H
 #define THIRD_PARTY_NEPER_COEF_H
 
@@ -44,3 +46,4 @@ struct neper_coef {
 struct neper_coef *neper_coef(void);
 
 #endif
+/* clang-format on */

--- a/common.c
+++ b/common.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <fcntl.h>
 #include <netinet/tcp.h>
 #include <stddef.h>
@@ -346,3 +348,4 @@ int create_suicide_timeout(int sec_to_suicide)
         }
         return 0;
 }
+/* clang-format on */

--- a/common.h
+++ b/common.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_COMMON_H
 #define THIRD_PARTY_NEPER_COMMON_H
 
@@ -169,3 +171,4 @@ const struct rate_conversion *auto_unit(const double throughput,
                                         const struct rate_conversion *opt,
                                         struct callbacks *);
 #endif
+/* clang-format on */

--- a/control_plane.c
+++ b/control_plane.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "control_plane.h"
 #include <netinet/tcp.h>
 #include <inttypes.h>
@@ -514,3 +516,4 @@ void control_plane_destroy(struct control_plane *cp)
 {
         free(cp);
 }
+/* clang-format on */

--- a/control_plane.h
+++ b/control_plane.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_CONTROL_PLANE_H
 #define THIRD_PARTY_NEPER_CONTROL_PLANE_H
 
@@ -36,3 +38,4 @@ int control_plane_incidents(struct control_plane *cp);
 void control_plane_destroy(struct control_plane *cp);
 
 #endif
+/* clang-format on */

--- a/countdown_cond.h
+++ b/countdown_cond.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef _COUNTDOWN_COND_H
 #define _COUNTDOWN_COND_H
 
@@ -92,3 +94,4 @@ static inline void countdown_cond_wait(struct countdown_cond *cc)
 }
 
 #endif
+/* clang-format on */

--- a/cpuinfo.c
+++ b/cpuinfo.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,3 +89,4 @@ int get_cpuinfo(struct cpuinfo *cpus, int max_cpus, struct callbacks *cb)
         fclose(f);
         return n;
 }
+/* clang-format on */

--- a/cpuinfo.h
+++ b/cpuinfo.h
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/* clang-format off */
 #include "lib.h"
 
 #ifndef THIRD_PARTY_NEPER_CPUINFO_H
@@ -35,3 +37,4 @@ struct cpuinfo {
 int get_cpuinfo(struct cpuinfo *cpus, int max_cpus, struct callbacks *cb);
 
 #endif
+/* clang-format on */

--- a/define_all_flags.c
+++ b/define_all_flags.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "lib.h"
@@ -183,3 +185,4 @@ struct flags_parser *add_flags_udp_stream(struct flags_parser *fp)
         return (fp);
 }
 
+/* clang-format on */

--- a/define_all_flags.h
+++ b/define_all_flags.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_DEFINE_ALL_FLAGS_H
 #define THIRD_PARTY_NEPER_DEFINE_ALL_FLAGS_H
 
@@ -32,3 +34,4 @@ struct flags_parser *add_flags_udp_rr(struct flags_parser *fp);
 struct flags_parser *add_flags_udp_stream(struct flags_parser *fp);
 
 #endif
+/* clang-format on */

--- a/flags.c
+++ b/flags.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "flags.h"
 
 #include <ctype.h>
@@ -369,3 +371,4 @@ void flags_parser_dump(struct flags_parser *fp)
                 print_flag(flag, fp->cb);
         }
 }
+/* clang-format on */

--- a/flags.h
+++ b/flags.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_FLAGS_H
 #define THIRD_PARTY_NEPER_FLAGS_H
 
@@ -85,3 +87,4 @@ void flags_parser_destroy(struct flags_parser *fp);
 } while (0)
 
 #endif
+/* clang-format on */

--- a/flow.c
+++ b/flow.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <linux/tcp.h>
 #include <linux/version.h>
 #include <stdint.h>
@@ -394,3 +396,4 @@ ssize_t flow_recv_zerocopy(struct flow *f, void *copybuf, size_t copybuf_len) {
 #endif
         return n_read;
 }
+/* clang-format on */

--- a/flow.h
+++ b/flow.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_FLOW_H
 #define THIRD_PARTY_NEPER_FLOW_H
 
@@ -77,3 +79,4 @@ void flow_init_rx_zerocopy(struct flow *f, int buffer_size,
 ssize_t flow_recv_zerocopy(struct flow *f, void *copybuf, size_t copybuf_len);
 
 #endif
+/* clang-format on */

--- a/hexdump.c
+++ b/hexdump.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "hexdump.h"
 #include <ctype.h>
 #include <string.h>
@@ -51,3 +53,4 @@ char *hexdump(const char *in, size_t in_len, char *out, size_t out_len)
         out[sizeof(row_buf) * num_rows] = '\0';
         return out;
 }
+/* clang-format on */

--- a/hexdump.h
+++ b/hexdump.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_HEXDUMP_H
 #define THIRD_PARTY_NEPER_HEXDUMP_H
 
@@ -22,3 +24,4 @@
 char *hexdump(const char *in, size_t in_len, char *out, size_t out_len);
 
 #endif
+/* clang-format on */

--- a/histo.c
+++ b/histo.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "histo.h"
 #include "common.h"
 #include "logging.h"
@@ -319,3 +321,4 @@ struct neper_histo *neper_histo_new(const struct thread *t, uint8_t k_bits)
 
         return ret;
 }
+/* clang-format on */

--- a/histo.h
+++ b/histo.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_HISTO_H
 #define THIRD_PARTY_NEPER_HISTO_H
 
@@ -74,3 +76,4 @@ void neper_histo_print(struct neper_histo *);
 void neper_histo_delete(struct neper_histo *);
 
 #endif
+/* clang-format on */

--- a/lib.h
+++ b/lib.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_LIB_H
 #define THIRD_PARTY_NEPER_LIB_H
 
@@ -156,3 +158,4 @@ int psp_crr(struct options *, struct callbacks *);
 #endif
 
 #endif
+/* clang-format on */

--- a/logging.c
+++ b/logging.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "logging.h"
 #include <errno.h>
 #include <libgen.h>
@@ -246,3 +248,4 @@ void logging_exit(struct callbacks *cb)
 {
         close_log();
 }
+/* clang-format on */

--- a/logging.h
+++ b/logging.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_LOGGING_H
 #define THIRD_PARTY_NEPER_LOGGING_H
 
@@ -41,3 +43,4 @@ void logging_exit(struct callbacks *);
                 LOG_FATAL(cb, fmt, ##args)
 
 #endif
+/* clang-format on */

--- a/loop.c
+++ b/loop.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <time.h>
 
 #include "common.h"
@@ -100,3 +102,4 @@ void *loop(struct thread *t)
         /* This is technically a thread callback so it must return a (void *) */
         return NULL;
 }
+/* clang-format on */

--- a/loop.h
+++ b/loop.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_LOOP_H
 #define THIRD_PARTY_NEPER_LOOP_H
 
@@ -22,3 +24,4 @@ struct thread;
 void *loop(struct thread *);
 
 #endif
+/* clang-format on */

--- a/or_die.c
+++ b/or_die.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "or_die.h"
 
@@ -104,3 +106,4 @@ int socket_or_die(int domain, int type, int protocol, struct callbacks *cb)
                 PLOG_FATAL(cb, "socket");
         return s;
 }
+/* clang-format on */

--- a/or_die.h
+++ b/or_die.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_OR_DIE_H
 #define THIRD_PARTY_NEPER_OR_DIE_H
 
@@ -36,3 +38,4 @@ void *realloc_or_die(void *ptr, size_t, struct callbacks *);
 int socket_or_die(int domain, int type, int protocol, struct callbacks *);
 
 #endif
+/* clang-format on */

--- a/parse.c
+++ b/parse.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <stdlib.h>
 #include <time.h>
 
@@ -117,3 +119,4 @@ void parse_duration(const char *arg, void *out, struct callbacks *cb)
         /* Never found a matching suffix. */
         LOG_FATAL(cb, "invalid suffix %s", suffix);
 }
+/* clang-format on */

--- a/parse.h
+++ b/parse.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_PARSE_H
 #define THIRD_PARTY_NEPER_PARSE_H
 
@@ -24,3 +26,4 @@ void parse_unit(const char *arg, void *out, struct callbacks *);
 void parse_duration(const char *arg, void *out, struct callbacks *cb);
 
 #endif
+/* clang-format on */

--- a/percentiles.c
+++ b/percentiles.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "percentiles.h"
 #include <errno.h>
 #include <limits.h>
@@ -92,3 +94,4 @@ void percentiles_print(const char *name, const void *var, struct callbacks *cb)
         PRINT(cb, name, "%s", s);
         free(s);
 }
+/* clang-format on */

--- a/percentiles.h
+++ b/percentiles.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_PERCENTILES_H
 #define THIRD_PARTY_NEPER_PERCENTILES_H
 
@@ -28,3 +30,4 @@ void percentiles_parse(const char *arg, void *out, struct callbacks *);
 void percentiles_print(const char *name, const void *var, struct callbacks *);
 
 #endif
+/* clang-format on */

--- a/pq.c
+++ b/pq.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "pq.h"
 #include "common.h"
 
@@ -139,3 +141,4 @@ struct neper_pq *neper_pq(double (*cmp)(void *, void *), uint32_t maxlen,
 
         return pq;
 }
+/* clang-format on */

--- a/pq.h
+++ b/pq.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_PQ_H
 #define THIRD_PARTY_NEPER_PQ_H
 
@@ -44,3 +46,4 @@ struct neper_pq *neper_pq(double (*cmp)(void *, void *), uint32_t maxlen,
                           struct callbacks *);
 
 #endif
+/* clang-format on */

--- a/print.c
+++ b/print.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "print.h"
 
 #include "common.h"
@@ -62,3 +64,4 @@ void print_rusage(FILE *csv, const struct rusage *rusage, const char *nl)
                 rusage->ru_nvcsw, rusage->ru_nivcsw);
         fprintf(csv, "%s", nl);
 }
+/* clang-format on */

--- a/print.h
+++ b/print.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_PRINT_H
 #define THIRD_PARTY_NEPER_PRINT_H
 
@@ -31,3 +33,4 @@ void print_latency_header(FILE *csv, const struct percentiles *);
 void print_rusage(FILE *csv, const struct rusage *, const char *nl);
 
 #endif
+/* clang-format on */

--- a/psp_crr.c
+++ b/psp_crr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "psp_lib.h"
 #include "rr.h"
@@ -46,3 +48,4 @@ int psp_crr(struct options *opts, struct callbacks *cb)
                 opts->nostats = true;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/psp_crr_main.c
+++ b/psp_crr_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "lib.h"
@@ -65,3 +67,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/psp_kernel.h
+++ b/psp_kernel.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef PSP_KERNEL_H_
 #define PSP_KERNEL_H_
 
@@ -47,3 +49,4 @@ struct psp_spi_tuple {
 };
 
 #endif  // PSP_KERNEL_H_
+/* clang-format on */

--- a/psp_lib.c
+++ b/psp_lib.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "psp_lib.h"
 #include "socket.h"
@@ -265,3 +267,4 @@ void psp_post_listen(struct thread *t, int s, struct addrinfo *ai) {
 
         pthread_mutex_unlock(&psp_key_lock);
 }
+/* clang-format on */

--- a/psp_lib.h
+++ b/psp_lib.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_PSP_LIB_H_
 #define THIRD_PARTY_NEPER_PSP_LIB_H_
 
@@ -45,3 +47,4 @@ void psp_pre_connect(struct thread *t, int s, struct addrinfo *ai);
 void psp_post_listen(struct thread *t, int s, struct addrinfo *ai);
 
 #endif  // THIRD_PARTY_NEPER_PSP_LIB_H_
+/* clang-format on */

--- a/psp_rr.c
+++ b/psp_rr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "psp_lib.h"
 #include "rr.h"
@@ -43,3 +45,4 @@ int psp_rr(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/psp_rr_main.c
+++ b/psp_rr_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "lib.h"
@@ -63,3 +65,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/psp_stream.c
+++ b/psp_stream.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "psp_lib.h"
 #include "socket.h"
@@ -43,3 +45,4 @@ int psp_stream(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/psp_stream_main.c
+++ b/psp_stream_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "parse.h"
@@ -86,3 +88,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/rr.c
+++ b/rr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 /*
  * This file implements six different state machines:
  * TCP_RR client/server, UDP_RR client/server, and TCP_CRR client/server
@@ -620,3 +622,4 @@ int rr_report_stats(struct thread *tinfo)
 
         return 0;
 }
+/* clang-format on */

--- a/rr.h
+++ b/rr.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_RR_H
 #define THIRD_PARTY_NEPER_RR_H
 
@@ -24,3 +26,4 @@ void rr_flow_init(struct thread *, int fd);
 int rr_report_stats(struct thread *);
 
 #endif
+/* clang-format on */

--- a/rusage.c
+++ b/rusage.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "rusage.h"
 #include "common.h"
 
@@ -167,3 +169,4 @@ struct neper_rusage *neper_rusage(double interval)
 
         return rusage;
 }
+/* clang-format on */

--- a/rusage.h
+++ b/rusage.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_RUSAGE_H
 #define THIRD_PARTY_NEPER_RUSAGE_H
 
@@ -43,3 +45,4 @@ void set_getrusage_enhanced(bool stime_use_proc, int num_threads);
 int getrusage_enhanced(int who, struct rusage *usage);
 
 #endif
+/* clang-format on */

--- a/snaps.c
+++ b/snaps.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "snaps.h"
 #include "common.h"
 #include "print.h"
@@ -128,3 +130,4 @@ struct neper_snaps *neper_snaps_init(struct neper_rusage *rusage,
 
         return snaps;
 }
+/* clang-format on */

--- a/snaps.h
+++ b/snaps.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_SNAPS_H
 #define THIRD_PARTY_NEPER_SNAPS_H
 
@@ -77,3 +79,4 @@ struct neper_snaps *neper_snaps_init(struct neper_rusage *,
                                      int total, int extra);
 
 #endif
+/* clang-format on */

--- a/socket.c
+++ b/socket.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flow.h"
 #include "socket.h"
@@ -352,3 +354,4 @@ void socket_connect_all(struct thread *t)
                 t->fn->fn_flow_init(t, s);
         }
 }
+/* clang-format on */

--- a/socket.h
+++ b/socket.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_SOCKET_H
 #define THIRD_PARTY_NEPER_SOCKET_H
 
@@ -25,3 +27,4 @@ int  socket_connect_one(struct thread *, int flags);
 void socket_connect_all(struct thread *);
 
 #endif
+/* clang-format on */

--- a/stats.c
+++ b/stats.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "stats.h"
 #include "coef.h"
 #include "common.h"
@@ -289,3 +291,4 @@ struct neper_stats *neper_stats_init(struct callbacks *cb)
 
         return stats;
 }
+/* clang-format on */

--- a/stats.h
+++ b/stats.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_STATS_H
 #define THIRD_PARTY_NEPER_STATS_H
 
@@ -79,3 +81,4 @@ struct neper_stats {
 struct neper_stats *neper_stats_init(struct callbacks *);
 
 #endif
+/* clang-format on */

--- a/stream.c
+++ b/stream.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "stream.h"
 
 #include "coef.h"
@@ -223,3 +225,4 @@ void stream_flow_init(struct thread *t, int fd)
 	if (t->opts->rx_zerocopy)
 		flow_init_rx_zerocopy(f, t->opts->buffer_size, t->cb);
 }
+/* clang-format on */

--- a/stream.h
+++ b/stream.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_STREAM_H
 #define THIRD_PARTY_NEPER_STREAM_H
 
@@ -27,3 +29,4 @@ void stream_handler(struct flow *, uint32_t events);
 int stream_report(struct thread *);
 
 #endif
+/* clang-format on */

--- a/tcp_crr.c
+++ b/tcp_crr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "rr.h"
 #include "socket.h"
@@ -41,3 +43,4 @@ int tcp_crr(struct options *opts, struct callbacks *cb)
                 opts->nostats = true;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/tcp_crr_main.c
+++ b/tcp_crr_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "lib.h"
@@ -64,3 +66,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/tcp_rr.c
+++ b/tcp_rr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "rr.h"
 #include "socket.h"
@@ -38,3 +40,4 @@ int tcp_rr(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/tcp_rr_main.c
+++ b/tcp_rr_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "lib.h"
@@ -62,3 +64,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/tcp_stream.c
+++ b/tcp_stream.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "socket.h"
 #include "stream.h"
@@ -38,3 +40,4 @@ int tcp_stream(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/tcp_stream_main.c
+++ b/tcp_stream_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "parse.h"
@@ -84,3 +86,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/thread.c
+++ b/thread.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include <sched.h>
 #include <stdint.h>
 #include <sys/epoll.h>
@@ -689,3 +691,4 @@ int run_main_thread(struct options *opts, struct callbacks *cb,
         free(data_pending);
         return ret;
 }
+/* clang-format on */

--- a/thread.h
+++ b/thread.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_THREAD_H
 #define THIRD_PARTY_NEPER_THREAD_H
 
@@ -158,3 +160,4 @@ void thread_flush_stat(struct thread *);
 void thread_clear_flow_or_die(struct thread*, struct flow *);
 
 #endif
+/* clang-format on */

--- a/udp_rr.c
+++ b/udp_rr.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "rr.h"
 #include "socket.h"
@@ -38,3 +40,4 @@ int udp_rr(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/udp_rr_main.c
+++ b/udp_rr_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "countdown_cond.h"
 #include "flags.h"
@@ -63,3 +65,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/udp_stream.c
+++ b/udp_stream.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "socket.h"
 #include "stream.h"
@@ -38,3 +40,4 @@ int udp_stream(struct options *opts, struct callbacks *cb)
         const struct neper_fn *fn = opts->client ? &client_fn : &server_fn;
         return run_main_thread(opts, cb, fn);
 }
+/* clang-format on */

--- a/udp_stream_main.c
+++ b/udp_stream_main.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "common.h"
 #include "flags.h"
 #include "parse.h"
@@ -70,3 +72,4 @@ exit:
         logging_exit(&cb);
         return exit_code;
 }
+/* clang-format on */

--- a/version.c
+++ b/version.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #include "version.h"
 #include <stdio.h>
 
@@ -37,3 +39,4 @@ void show_version(void)
 {
         printf("%s\n", get_version());
 }
+/* clang-format on */

--- a/version.h
+++ b/version.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* clang-format off */
+
 #ifndef THIRD_PARTY_NEPER_VERSION_H
 #define THIRD_PARTY_NEPER_VERSION_H
 
@@ -29,3 +31,4 @@ void show_version(void);
 #endif
 
 #endif
+/* clang-format on */


### PR DESCRIPTION
It's run automatically by many automated tools and wreaks havoc on commit diffs. We should, maybe, go back later and re-enable it.